### PR TITLE
STM: Added missing state placeholders, TODOs and localised data objects

### DIFF
--- a/src/state_machine/main.cpp
+++ b/src/state_machine/main.cpp
@@ -26,12 +26,16 @@ namespace state_machine {
 
 Main::Main(uint8_t id, Logger& log) : Thread(id, log)
 {
-  ready_ = new Ready(log_, this);  // constructing state object for Idle
-  accelerating_ = new Accelerating(log_, this);  // constructing state object for Accelerating
-  braking_ = new Braking(log_, this);  // constructing state object for Braking
-  finished_ = new Finished(log_, this);  // constructing state object for Finished
+  // constructing state objects
+  idling_          = new Idling(log_, this);
+  calibrating_     = new Calibrating(log_, this);
+  ready_           = new Ready(log_, this);
+  accelerating_    = new Accelerating(log_, this);
+  nominal_braking_ = new NominalBraking(log_, this);
+  finished_        = new Finished(log_, this);
+  failure_braking_ = new FailureBraking(log_, this);
 
-  current_state_ = ready_;  // set current state to point to Idle
+  current_state_ = idling_;  // set current state to point to Idle
 }
 
 /**

--- a/src/state_machine/main.hpp
+++ b/src/state_machine/main.hpp
@@ -39,21 +39,29 @@ using data::ModuleStatus;
 
 namespace state_machine {
 
+class Idling;
+class Calibrating;
 class State;
 class Ready;
 class Accelerating;
-class Braking;
+class NominalBraking;
 class Finished;
+class FailureBraking;
+class FailureStopped;
 class Main: public Thread {
  public:
   explicit Main(uint8_t id, Logger& log);
   void run() override;
 
   State          *current_state_;
+  Idling         *idling_;
+  Calibrating    *calibrating_;
   Ready          *ready_;
   Accelerating   *accelerating_;
-  Braking        *braking_;
+  NominalBraking *nominal_braking_;
   Finished       *finished_;
+  FailureBraking *failure_braking_;
+  FailureStopped *failure_stopped_;
 };
 
 }  // namespace state_machine

--- a/src/state_machine/state.hpp
+++ b/src/state_machine/state.hpp
@@ -48,15 +48,26 @@ class State {
   Logger&               log_;
   data::Data&           data_;
 
-  data::Telemetry       telemetry_data_;
-  data::Navigation      nav_data_;
-  data::StateMachine    sm_data_;
-  data::Motors          motor_data_;
-  data::Sensors         sensors_data_;
-  data::EmergencyBrakes brakes_data_;
-
  protected:
   Main* state_machine_;
+};
+
+class Idling : public State {
+ public:
+  Idling(Logger& log, Main* state_machine) : State(log, state_machine) {}
+
+  /*
+   * @brief   Checks for calibration command
+   */
+  void transitionCheck();
+};
+
+class Calibrating : public State {
+ public:
+  Calibrating(Logger& log, Main* state_machine) : State(log, state_machine) {}
+
+  // TODO(Efe): Add comment.
+  void transitionCheck();
 };
 
 class Ready : public State {
@@ -79,9 +90,9 @@ class Accelerating : public State {
   void transitionCheck();
 };
 
-class Braking : public State {
+class NominalBraking : public State {
  public:
-  Braking(Logger& log, Main* state_machine) : State(log, state_machine) {}
+  NominalBraking(Logger& log, Main* state_machine) : State(log, state_machine) {}
   void transitionCheck();
 };
 
@@ -92,6 +103,22 @@ class Finished : public State {
   /*
    * @brief   Checks if command to reset was sent
    */
+  void transitionCheck();
+};
+
+class FailureBraking : public State {
+ public:
+  FailureBraking(Logger& log, Main* state_machine) : State(log, state_machine) {}
+
+  // TODO(Franz): Add comment.
+  void transitionCheck();
+};
+
+class FailureStopped : public State {
+ public:
+  FailureStopped(Logger& log, Main* state_machine) : State(log, state_machine) {}
+
+  // TODO(Yining): Add comment.
   void transitionCheck();
 };
 


### PR DESCRIPTION
## Description
Prepares this repository for concurrent work by the SM team.

## Changes
- `Renamed Braking` to `NominalBraking`
- `Added Idling`, `Calibrating`, `FailureBraking` and `FailureStopped` states
- Localised data objects to each transition function. It does not make sense to me that each state allocates space for each modules data individually. This can be done via stack allocations in each transition function which should be very quick, i.e. not measurable, even when running the function many times a second. If there is something wrong with this approach we can move this to `Main` later on but I feel like this would affect readability.