### PR TITLE
STM: Failure braking transitions

### DIFF
--- a/src/state_machine/main.cpp
+++ b/src/state_machine/main.cpp
@@ -17,14 +17,14 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <cstdint>
-
 #include "state_machine/main.hpp"
+
+#include <cstdint>
 
 namespace hyped {
 namespace state_machine {
 
-Main::Main(uint8_t id, Logger& log) : Thread(id, log)
+Main::Main(uint8_t id, Logger &log) : Thread(id, log)
 {
   // constructing state objects
   idling_          = new Idling(log_, this);
@@ -39,15 +39,15 @@ Main::Main(uint8_t id, Logger& log) : Thread(id, log)
 }
 
 /**
-  *  @brief  Runs state machine thread.
-  */
+ *  @brief  Runs state machine thread.
+ */
 void Main::run()
 {
-  utils::System& sys = utils::System::getSystem();
-  data::Data& data = data::Data::getInstance();
+  utils::System &sys = utils::System::getSystem();
+  data::Data &data   = data::Data::getInstance();
 
   data::StateMachine sm_data = data.getStateMachineData();
-  sm_data.current_state = data::State::kReady;  // set current state in data structure
+  sm_data.current_state      = data::State::kReady;  // set current state in data structure
   data.setStateMachineData(sm_data);
 
   while (sys.running_) {

--- a/src/state_machine/state.hpp
+++ b/src/state_machine/state.hpp
@@ -30,8 +30,8 @@
 
 namespace hyped {
 
-using utils::Logger;
 using data::ModuleStatus;
+using utils::Logger;
 
 namespace state_machine {
 
@@ -39,22 +39,22 @@ class Main;  // Forward declaration
 
 class State {
  public:
-  State(Logger& log, Main* state_machine);
+  State(Logger &log, Main *state_machine);
 
   void checkEmergencyStop();
 
   virtual void transitionCheck() = 0;
 
-  Logger&               log_;
-  data::Data&           data_;
+  Logger &log_;
+  data::Data &data_;
 
  protected:
-  Main* state_machine_;
+  Main *state_machine_;
 };
 
 class Idling : public State {
  public:
-  Idling(Logger& log, Main* state_machine) : State(log, state_machine) {}
+  Idling(Logger &log, Main *state_machine) : State(log, state_machine) {}
 
   /*
    * @brief   Checks for calibration command
@@ -64,7 +64,7 @@ class Idling : public State {
 
 class Calibrating : public State {
  public:
-  Calibrating(Logger& log, Main* state_machine) : State(log, state_machine) {}
+  Calibrating(Logger &log, Main *state_machine) : State(log, state_machine) {}
 
   // TODO(Efe): Add comment.
   void transitionCheck();
@@ -72,7 +72,7 @@ class Calibrating : public State {
 
 class Ready : public State {
  public:
-  Ready(Logger& log, Main* state_machine) : State(log, state_machine) {}
+  Ready(Logger &log, Main *state_machine) : State(log, state_machine) {}
 
   /*
    * @brief   Checks for launch command
@@ -82,7 +82,12 @@ class Ready : public State {
 
 class Accelerating : public State {
  public:
-  Accelerating(Logger& log, Main* state_machine) : State(log, state_machine) {}
+  Accelerating(Logger &log, Main *state_machine) : State(log, state_machine) {}
+
+  /*
+   * @brief   Checks for critical failure during run.
+   */
+  void checkEmergencyStop();
 
   /*
    * @brief   Checks if max distance reached
@@ -92,13 +97,22 @@ class Accelerating : public State {
 
 class NominalBraking : public State {
  public:
-  NominalBraking(Logger& log, Main* state_machine) : State(log, state_machine) {}
+  NominalBraking(Logger &log, Main *state_machine) : State(log, state_machine) {}
+
+  /*
+   * @brief   Checks for critical failure during run.
+   */
+  void checkEmergencyStop();
+
+  /*
+   * @brief   Checks whether the pod has stopped.
+   */
   void transitionCheck();
 };
 
 class Finished : public State {
  public:
-  Finished(Logger& log, Main* state_machine) : State(log, state_machine) {}
+  Finished(Logger &log, Main *state_machine) : State(log, state_machine) {}
 
   /*
    * @brief   Checks if command to reset was sent
@@ -108,7 +122,7 @@ class Finished : public State {
 
 class FailureBraking : public State {
  public:
-  FailureBraking(Logger& log, Main* state_machine) : State(log, state_machine) {}
+  FailureBraking(Logger &log, Main *state_machine) : State(log, state_machine) {}
 
   // TODO(Franz): Add comment.
   void transitionCheck();
@@ -116,7 +130,7 @@ class FailureBraking : public State {
 
 class FailureStopped : public State {
  public:
-  FailureStopped(Logger& log, Main* state_machine) : State(log, state_machine) {}
+  FailureStopped(Logger &log, Main *state_machine) : State(log, state_machine) {}
 
   // TODO(Yining): Add comment.
   void transitionCheck();


### PR DESCRIPTION
## Description

Implements the failure state as described [here](https://docs.google.com/document/d/1TZDZqiPdCRhjc8oPXj7X2hkzdafsIf8oNSk6IS6lQZg/edit).

This does not attempt to be clever or efficient. 

Notably, the functions `Accelerating::checkEmergencyStop` and `NominalBraking::checkEmergencyStop` are identical. Further, to check for a transition from `Accelerating` we now acquire the lock for all other modules, some of them twice. 

Those issues may be tackled in week 8.