### PR TITLE
Remove RESET command and related states

### DIFF
--- a/src/data/data.hpp
+++ b/src/data/data.hpp
@@ -145,7 +145,6 @@ struct Telemetry : public Module {
   static constexpr float run_length = 1250;  // m
   bool calibrate_command = false;
   bool launch_command = false;
-  bool reset_command = false;
   bool service_propulsion_go = false;
   bool emergency_stop_command = false;
   bool nominal_braking_command = true;

--- a/src/state_machine/event.hpp
+++ b/src/state_machine/event.hpp
@@ -32,8 +32,7 @@ enum Event {
   kMaxDistanceReached,
   kAtRest,
   kOnExit,
-  kFinish,
-  kReset
+  kFinish
 };
 
 }}   // namespace hyped::state_machine

--- a/src/state_machine/main.cpp
+++ b/src/state_machine/main.cpp
@@ -93,7 +93,6 @@ void Main::run()
       case data::State::kInvalid:
         log_.ERR("STATE", "we are in Invalid state");
       case data::State::kFinished:
-        if (checkReset())                break;
       case data::State::kFailureStopped:
       default:
         break;
@@ -129,18 +128,6 @@ bool Main::checkSystemsChecked()
       emergency_brakes_data_.module_status == ModuleStatus::kReady) {
     log_.INFO("STATE", "systems ready");
     hypedMachine.handleEvent(kSystemsChecked);
-    return true;
-  }
-  return false;
-}
-
-bool Main::checkReset()
-{
-  if (telemetry_data_.reset_command) {
-    log_.INFO("STATE", "reset command received");
-    hypedMachine.handleEvent(kReset);
-    telemetry_data_.reset_command = false;  // reset the command to false
-    data_.setTelemetryData(telemetry_data_);
     return true;
   }
   return false;

--- a/src/state_machine/main.hpp
+++ b/src/state_machine/main.hpp
@@ -50,7 +50,6 @@ class Main: public Thread {
   // return true iff the event has been fired
   bool checkInitialised();
   bool checkSystemsChecked();
-  bool checkReset();
   bool checkOnStart();
   bool checkTelemetryCriticalFailure();
   bool checkCriticalFailure();

--- a/src/state_machine/states.cpp
+++ b/src/state_machine/states.cpp
@@ -120,9 +120,7 @@ void FailureStopped::entry()
 
 void FailureStopped::react(HypedMachine &machine, Event event)
 {
-  if (event == kReset) {
-    machine.transition(new(alloc_) Idle());
-  }
+  return;
 }
 
 void RunComplete::entry()
@@ -160,9 +158,7 @@ void Finished::entry()
 
 void Finished::react(HypedMachine &machine, Event event)
 {
-  if (event == kReset) {
-    machine.transition(new(alloc_) Idle());
-  }
+  return;
 }
 
 

--- a/src/telemetry/recvloop.cpp
+++ b/src/telemetry/recvloop.cpp
@@ -66,9 +66,6 @@ void RecvLoop::run()
     } else if (message == "LAUNCH") {
       log_.INFO("Telemetry", "FROM SERVER: LAUNCH");
       telem_data_struct.launch_command = true;
-    } else if (message == "RESET") {
-      log_.INFO("Telemetry", "FROM SERVER: RESET");
-      telem_data_struct.reset_command = true;
     } else if (message == "SERVER_PROPULSION_GO") {
       log_.INFO("Telemetry", "FROM SERVER: SERVICE_PROPULSION_GO");
       telem_data_struct.service_propulsion_go = true;


### PR DESCRIPTION
## Description
RESET command is unnecessary, as none of the subsystems can currently handle it (basically a dead button in GUI) and they shouldn't try to handle it. It would be dangerous for the pod to go back to the initial state at the end of the run.

[https://app.clickup.com/t/9rvg2m](https://app.clickup.com/t/9rvg2m)

## Changes
- Removed RESET command handling in telemetry receive loop
- Removed RESET event
- Removed transitioning from `kFinished` and `kFailureStopped` states to `kIdle` state after receiving RESET command
