### PR TITLE
Implement fake stepper

### DIFF
--- a/src/embrakes/fake_stepper.cpp
+++ b/src/embrakes/fake_stepper.cpp
@@ -1,0 +1,71 @@
+/*
+ * Author: Atte Niemi
+ * Organisation: HYPED
+ * Date:
+ * Description:
+ *
+ *    Copyright 2020 HYPED
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "embrakes/fake_stepper.hpp"
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+namespace hyped {
+namespace embrakes {
+
+FakeStepper::FakeStepper(Logger& log, uint8_t id)
+    : log_(log),
+      data_(data::Data::getInstance()),
+      em_brakes_data_(data_.getEmergencyBrakesData()),
+      brake_id_(id),
+      is_clamped_(true),
+      fake_button_(true) {}
+
+void FakeStepper::checkHome()  // WHAT'S THE PURPOSE OF CHECKHOME?!
+{
+  return;
+}
+
+void FakeStepper::sendRetract()
+{
+  log_.INFO("Fake Stepper", "Sending a retract message to brake %i", brake_id_);
+  // set data to zero
+  is_clamped_ = false;
+}
+
+void FakeStepper::sendClamp()
+{
+  log_.INFO("Fake Stepper", "Sending a retract message to brake %i", brake_id_);
+  // set data to one
+  is_clamped_ = true;
+}
+
+void FakeStepper::checkAccFailure()
+{
+  // For now, doesn't fail.
+  return;
+}
+
+void FakeStepper::checkBrakingFailure()
+{
+  // For now, fake brakes don't fail.
+  return;
+}
+
+bool FakeStepper::checkClamped() { return is_clamped_; }
+}  // namespace embrakes
+}  // namespace hyped

--- a/src/embrakes/fake_stepper.cpp
+++ b/src/embrakes/fake_stepper.cpp
@@ -20,10 +20,6 @@
 
 #include "embrakes/fake_stepper.hpp"
 
-#include <fstream>
-#include <iostream>
-#include <sstream>
-
 namespace hyped {
 namespace embrakes {
 

--- a/src/embrakes/fake_stepper.hpp
+++ b/src/embrakes/fake_stepper.hpp
@@ -1,0 +1,85 @@
+/*
+ * Author: Atte Niemi
+ * Organisation: HYPED
+ * Date:
+ * Description:
+ *
+ *    Copyright 2020 HYPED
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#ifndef EMBRAKES_FAKE_STEPPER_HPP_
+#define EMBRAKES_FAKE_STEPPER_HPP_
+
+#include "data/data.hpp"
+#include "embrakes/interface.hpp"
+#include "utils/concurrent/thread.hpp"
+#include "utils/logger.hpp"
+#include "utils/system.hpp"
+#include "utils/timer.hpp"
+
+namespace hyped {
+
+using data::ModuleStatus;
+using utils::Logger;
+using utils::concurrent::Thread;
+
+namespace embrakes {
+
+class FakeStepper : public StepperInterface {
+ public:
+  /**
+   * @brief Construct a new Stepper object
+   * @param log, node id
+   */
+  FakeStepper(Logger& log, uint8_t id);
+
+  /**
+   * @brief {checks if brake's button is pressed, notes change in the data
+   * struct}
+   */
+  void checkHome() override;
+
+  /**
+   * @brief sends retract message
+   */
+  void sendRetract() override;
+
+  /**
+   * @brief sends clamp message
+   */
+  void sendClamp() override;
+
+  /**
+   * @brief checks for brake failure during acceleration
+   */
+  void checkAccFailure() override;
+
+  void checkBrakingFailure() override;
+
+  bool checkClamped() override;
+
+ private:
+  uint8_t fake_button_;
+  utils::Logger& log_;
+  data::Data& data_;
+  data::EmergencyBrakes em_brakes_data_;
+  uint8_t brake_id_;
+  uint8_t is_clamped_;
+  uint64_t timer;
+};
+
+}  // namespace embrakes
+}  // namespace hyped
+
+#endif  // EMBRAKES_FAKE_STEPPER_HPP_

--- a/src/embrakes/fake_stepper.hpp
+++ b/src/embrakes/fake_stepper.hpp
@@ -26,7 +26,7 @@
 #include "utils/concurrent/thread.hpp"
 #include "utils/logger.hpp"
 #include "utils/system.hpp"
-#include "utils/timer.hpp"
+#include "utils/concurrent/thread.hpp"
 
 namespace hyped {
 
@@ -76,7 +76,6 @@ class FakeStepper : public StepperInterface {
   data::EmergencyBrakes em_brakes_data_;
   uint8_t brake_id_;
   uint8_t is_clamped_;
-  uint64_t timer;
 };
 
 }  // namespace embrakes

--- a/src/embrakes/fake_stepper.hpp
+++ b/src/embrakes/fake_stepper.hpp
@@ -70,7 +70,7 @@ class FakeStepper : public StepperInterface {
   bool checkClamped() override;
 
  private:
-  uint8_t fake_button_;
+  bool fake_button_;
   utils::Logger& log_;
   data::Data& data_;
   data::EmergencyBrakes em_brakes_data_;

--- a/src/embrakes/interface.hpp
+++ b/src/embrakes/interface.hpp
@@ -1,0 +1,40 @@
+/*
+ * Author: Atte Niemi
+ * Organisation: HYPED
+ * Date:
+ * Description: Main brake interfaces used to create fake brakes
+ *
+ *    Copyright 2020 HYPED
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef EMBRAKES_INTERFACE_HPP_
+#define EMBRAKES_INTERFACE_HPP_
+
+namespace hyped {
+
+namespace embrakes {
+
+class StepperInterface {
+ public:
+  virtual void checkHome() = 0;
+  virtual void sendRetract() = 0;
+  virtual void sendClamp() = 0;
+  virtual void checkAccFailure() = 0;
+  virtual void checkBrakingFailure() = 0;
+  virtual bool checkClamped() = 0;
+};
+
+}  // namespace embrakes
+}  // namespace hyped
+#endif  // EMBRAKES_INTERFACE_HPP_

--- a/src/embrakes/main.cpp
+++ b/src/embrakes/main.cpp
@@ -58,8 +58,8 @@ void Main::run()
     switch (sm_data_.current_state) {
       case data::State::kIdle:
         if (!tlm_data_.nominal_braking_command) {
-          log_.INFO("Brakes", "RETRACT COMMAND");
           if (brake_1->checkClamped()) {
+            log_.INFO("Brakes", "RETRACT COMMAND");
             brake_1->sendRetract();
           }
           // if(brake_2->checkClamped()){
@@ -78,8 +78,8 @@ void Main::run()
           // brake_4->checkHome();
 
         } else if (tlm_data_.nominal_braking_command) {
-          log_.INFO("Brakes", "ENGAGE COMMAND");
           if (!brake_1->checkClamped()) {
+            log_.INFO("Brakes", "ENGAGE COMMAND");
             brake_1->sendClamp();
           }
           // if(!brake_2->checkClamped()){

--- a/src/embrakes/main.cpp
+++ b/src/embrakes/main.cpp
@@ -59,135 +59,56 @@ void Main::run()
       case data::State::kIdle:
         if (!tlm_data_.nominal_braking_command) {
           if (brake_1->checkClamped()) {
-            log_.INFO("Brakes", "RETRACT COMMAND");
+            log_.INFO("Brakes", "Sending retract command");
             brake_1->sendRetract();
           }
-          // if(brake_2->checkClamped()){
-          //   brake_2->sendRetract();
-          // }
-          // if(brake_3->checkClamped){
-          //   brake_3->sendRetract();
-          // }
-          // if(brake_4->checkClamped){
-          //   brake_4->sendRetract();
-          // }
           Thread::sleep(1000);
           brake_1->checkHome();
-          // brake_2->checkHome();
-          // brake_3->checkHome();
-          // brake_4->checkHome();
-
         } else if (tlm_data_.nominal_braking_command) {
           if (!brake_1->checkClamped()) {
-            log_.INFO("Brakes", "ENGAGE COMMAND");
+            log_.INFO("Brakes", "Sending engage command");
             brake_1->sendClamp();
           }
-          // if(!brake_2->checkClamped()){
-          //   brake_2->sendClamp();
-          // }
-          // if(!brake_3->checkClamped){
-          //   brake_3->sendClamp();
-          // }
-          // if(!brake_4->checkClamped){
-          //   brake_4->sendClamp();
-          // }
           Thread::sleep(1000);
           brake_1->checkHome();
-          // brake_2->checkHome();
-          // brake_3->checkHome();
-          // brake_4->checkHome();
         }
         break;
       case data::State::kCalibrating:
         if (brake_1->checkClamped()) {
           brake_1->sendRetract();
         }
-        // if(brake_2->checkClamped()){
-        //   brake_2->sendRetract();
-        // }
-        // if(brake_3->checkClamped()){
-        //   brake_3->sendRetract();
-        // }
-        // if(brake_4->checkClamped()){
-        //   brake_4->sendRetract();
-        // }
         if (!brake_1->checkClamped()) {
           em_brakes_.module_status = ModuleStatus::kReady;
           data_.setEmergencyBrakesData(em_brakes_);
         }
         Thread::sleep(1000);
         brake_1->checkHome();
-        // brake_2->checkHome();
-        // brake_3->checkHome();
-        // brake_4->checkHome();
         break;
       case data::State::kAccelerating:
         brake_1->checkAccFailure();
-        // brake_2->checkAccFailure();
-        // brake_3->checkAccFailure();
-        // brake_4->checkAccFailure();
         break;
       case data::State::kNominalBraking:
         if (!brake_1->checkClamped()) {
           brake_1->sendClamp();
         }
-        // if(!brake_2->checkClamped()){
-        //   brake_2->sendClamp();
-        // }
-        // if(!brake_3->checkClamped()){
-        //   brake_3->sendClamp();
-        // }
-        // if(!brake_4->checkClamped()){
-        //   brake_4->sendClamp();
-        // }
         Thread::sleep(1000);
         brake_1->checkHome();
-        // brake_2->checkHome();
-        // brake_3->checkHome();
-        // brake_4->checkHome();
 
         brake_1->checkBrakingFailure();
-        // brake_2->checkBrakingFailure();
-        // brake_3->checkBrakingFailure();
-        // brake_4->checkBrakingFailure();
         break;
       case data::State::kFinished:
         if (tlm_data_.nominal_braking_command) {
           if (brake_1->checkClamped()) {
             brake_1->sendRetract();
           }
-          // if(brake_2->checkClamped()){
-          //   brake_2->sendRetract();
-          // }
-          // if(brake_3->checkClamped){
-          //   brake_3->sendRetract();
-          // }
-          // if(brake_4->checkClamped){
-          //   brake_4->sendRetract();
-          // }
           Thread::sleep(1000);
           brake_1->checkHome();
-          // brake_2->checkHome();
-          // brake_3->checkHome();
-          // brake_4->checkHome();
         } else if (!tlm_data_.nominal_braking_command) {
           if (!brake_1->checkClamped()) {
             brake_1->sendClamp();
           }
-          // if(!brake_2->checkClamped()){
-          //   brake_2->sendClamp();
-          // }
-          // if(!brake_3->checkClamped){
-          //   brake_3->sendClamp();
-          // }
-          // if(!brake_4->checkClamped){
-          //   brake_4->sendClamp();
-          // }
           Thread::sleep(500);
           brake_1->checkHome();
-          // brake_2->checkHome();
-          // brake_3->checkHome();
-          // brake_4->checkHome();
         }
         break;
       default:

--- a/src/embrakes/main.cpp
+++ b/src/embrakes/main.cpp
@@ -1,5 +1,5 @@
 /*
-* Author: Kornelija Sukyte
+* Author: Kornelija Sukyte, Atte Niemi
 * Organisation: HYPED
 * Date:
 * Description: Entrypoint class to the embrake module, started in it's own thread.
@@ -33,10 +33,14 @@ Main::Main(uint8_t id, Logger &log)
     command_pins_[i] = sys_.config->embrakes.command[i];
     button_pins_[i] = sys_.config->embrakes.button[i];
   }
-  brake_1 = new Stepper(command_pins_[0], button_pins_[0], log_, 1);
-  // Stepper brake_2(command_pins_[1], button_pins_[1], log_, 2);
-  // Stepper brake_3(command_pins_[2], button_pins_[2], log_, 3);
-  // Stepper brake_4(command_pins_[3], button_pins_[3], log_, 4);
+  if (sys_.fake_embrakes) {
+    brake_1 = new FakeStepper(log_, 1);
+  } else {
+    brake_1 = new Stepper(command_pins_[0], button_pins_[0], log_, 1);
+    // Stepper brake_2(command_pins_[1], button_pins_[1], log_, 2);
+    // Stepper brake_3(command_pins_[2], button_pins_[2], log_, 3);
+    // Stepper brake_4(command_pins_[3], button_pins_[3], log_, 4);
+  }
 }
 
 void Main::run()

--- a/src/embrakes/main.hpp
+++ b/src/embrakes/main.hpp
@@ -1,5 +1,5 @@
 /*
-* Author: Kornelija Sukyte
+* Author: Kornelija Sukyte, Atte Niemi
 * Organisation: HYPED
 * Date:
 * Description: Entrypoint class to the embrake module, started in it's own thread.
@@ -25,6 +25,7 @@
 #include "data/data.hpp"
 
 #include "embrakes/stepper.hpp"
+#include "embrakes/fake_stepper.hpp"
 
 namespace hyped {
 
@@ -59,7 +60,7 @@ class Main : public Thread
     data::Telemetry        tlm_data_;
     int                    command_pins_[4];
     int                    button_pins_[4];
-    Stepper*               brake_1;
+    StepperInterface*      brake_1;
     // Stepper*               brake_2;
     // Stepper*               brake_3;
     // Stepper*               brake_4;

--- a/src/embrakes/stepper.cpp
+++ b/src/embrakes/stepper.cpp
@@ -1,5 +1,5 @@
 /*
-* Author: Kornelija Sukyte
+* Author: Kornelija Sukyte, Atte Niemi
 * Organisation: HYPED
 * Date:
 * Description:
@@ -62,28 +62,18 @@ void Stepper::sendClamp()
 void Stepper::checkAccFailure()
 {
   if (!button_.read()) {
-    timer = utils::Timer::getTimeMicros();
-    if ((utils::Timer::getTimeMicros() - timer > 200000) && !button_.read()) {
-      log_.ERR("Brakes", "Brake %b failure", brake_id_);
-      em_brakes_data_.module_status = ModuleStatus::kCriticalFailure;
-      data_.setEmergencyBrakesData(em_brakes_data_);
-    } else {
-      return;
-    }
+    log_.ERR("Brakes", "Brake %b failure", brake_id_);
+    em_brakes_data_.module_status = ModuleStatus::kCriticalFailure;
+    data_.setEmergencyBrakesData(em_brakes_data_);
   }
 }
 
 void Stepper::checkBrakingFailure()
 {
   if (button_.read()) {
-    timer = utils::Timer::getTimeMicros();
-    if ((utils::Timer::getTimeMicros() - timer > 200000) && button_.read()) {
-      log_.ERR("Brakes", "Brake %b failure", brake_id_);
-      em_brakes_data_.module_status = ModuleStatus::kCriticalFailure;
-      data_.setEmergencyBrakesData(em_brakes_data_);
-    } else {
-      return;
-    }
+    log_.ERR("Brakes", "Brake %b failure", brake_id_);
+    em_brakes_data_.module_status = ModuleStatus::kCriticalFailure;
+    data_.setEmergencyBrakesData(em_brakes_data_);
   }
 }
 

--- a/src/embrakes/stepper.hpp
+++ b/src/embrakes/stepper.hpp
@@ -1,5 +1,5 @@
 /*
-* Author: Kornelija Sukyte
+* Author: Kornelija Sukyte, Atte Niemi
 * Organisation: HYPED
 * Date:
 * Description:

--- a/src/embrakes/stepper.hpp
+++ b/src/embrakes/stepper.hpp
@@ -25,6 +25,7 @@
 #include "utils/system.hpp"
 #include "utils/concurrent/thread.hpp"
 #include "data/data.hpp"
+#include "embrakes/interface.hpp"
 
 namespace hyped {
 
@@ -35,7 +36,7 @@ using data::ModuleStatus;
 
 namespace embrakes {
 
-class Stepper {
+class Stepper : public StepperInterface {
  public:
   /**
    * @brief Construct a new Stepper object
@@ -46,26 +47,26 @@ class Stepper {
   /**
    * @brief {checks if brake's button is pressed, notes change in the data struct}
    */
-  void checkHome();
+  void checkHome() override;
 
   /**
    * @brief sends retract message
    */
-  void sendRetract();
+  void sendRetract() override;
 
   /**
    * @brief sends clamp message
    */
-  void sendClamp();
+  void sendClamp() override;
 
   /**
    * @brief checks for brake failure during acceleration
    */
-  void checkAccFailure();
+  void checkAccFailure() override;
 
-  void checkBrakingFailure();
+  void checkBrakingFailure() override;
 
-  bool checkClamped();
+  bool checkClamped() override;
 
  private:
   utils::Logger&        log_;

--- a/src/embrakes/stepper.hpp
+++ b/src/embrakes/stepper.hpp
@@ -19,7 +19,6 @@
 #ifndef EMBRAKES_STEPPER_HPP_
 #define EMBRAKES_STEPPER_HPP_
 
-#include "utils/timer.hpp"
 #include "utils/logger.hpp"
 #include "utils/io/gpio.hpp"
 #include "utils/system.hpp"
@@ -76,7 +75,6 @@ class Stepper : public StepperInterface {
   GPIO                  button_;
   uint8_t               brake_id_;
   uint8_t               is_clamped_;
-  uint64_t              timer;
 };
 
 }}  // namespace hyped::embrakes


### PR DESCRIPTION
## Description
Give a brief summary of what this PR contributes 

[*Click up link*](https://app.clickup.com/t/9uyxd9)
Also fixes [this issue](https://app.clickup.com/t/9uqj4d)

## Changes

- Implemented fake stepper
    - This required implementing a StepperInterface for stepper and fake stepper
- Removed unnecessary code from `src/embrakes/stepper.cpp`


## Additional Info 
`./hyped --fake_imu --fake_batteries --fake_keyence --fake_temperature --fake_motors --fake_highpower --telemetry_off --fake_embrakes` will no longer produce a stream of GPIO errors.