### PR TITLE
Renamed reset to shutdown

### DIFF
--- a/src/data/data.hpp
+++ b/src/data/data.hpp
@@ -145,7 +145,7 @@ struct Telemetry : public Module {
   static constexpr float run_length = 1250;  // m
   bool calibrate_command = false;
   bool launch_command = false;
-  bool reset_command = false;
+  bool shutdown_command = false;
   bool service_propulsion_go = false;
   bool emergency_stop_command = false;
   bool nominal_braking_command = true;

--- a/src/state_machine/state.cpp
+++ b/src/state_machine/state.cpp
@@ -282,8 +282,8 @@ void Finished::transitionCheck()
   utils::System &sys             = utils::System::getSystem();
   data::Telemetry telemetry_data = data_.getTelemetryData();
 
-  if (telemetry_data.reset_command) {
-    log_.INFO("STM", "Reset command received");
+  if (telemetry_data.shutdown_command) {
+    log_.INFO("STM", "Shutdown command received");
     log_.INFO("STM", "System is shutting down");
     sys.running_ = false;
   }
@@ -310,8 +310,8 @@ void FailureStopped::transitionCheck()
   utils::System &sys             = utils::System::getSystem();
   data::Telemetry telemetry_data = data_.getTelemetryData();
 
-  if (telemetry_data.reset_command) {
-    log_.INFO("STM", "FailureStopped command received");
+  if (telemetry_data.shutdown_command) {
+    log_.INFO("STM", "Shutdown command received");
     log_.INFO("STM", "System is shutting down");
     sys.running_ = false;
   }

--- a/src/state_machine/state.hpp
+++ b/src/state_machine/state.hpp
@@ -117,7 +117,7 @@ class Finished : public State {
   Finished(Logger &log, Main *state_machine) : State(log, state_machine) {}
 
   /*
-   * @brief   Checks if command to reset was sent
+   * @brief   Checks if command to shut down was sent
    */
   void transitionCheck();
 };

--- a/src/telemetry/recvloop.cpp
+++ b/src/telemetry/recvloop.cpp
@@ -66,9 +66,9 @@ void RecvLoop::run()
     } else if (message == "LAUNCH") {
       log_.INFO("Telemetry", "FROM SERVER: LAUNCH");
       telem_data_struct.launch_command = true;
-    } else if (message == "RESET") {
-      log_.INFO("Telemetry", "FROM SERVER: RESET");
-      telem_data_struct.reset_command = true;
+    } else if (message == "SHUTDOWN") {
+      log_.INFO("Telemetry", "FROM SERVER: SHUTDOWN");
+      telem_data_struct.shutdown_command = true;
     } else if (message == "SERVER_PROPULSION_GO") {
       log_.INFO("Telemetry", "FROM SERVER: SERVICE_PROPULSION_GO");
       telem_data_struct.service_propulsion_go = true;


### PR DESCRIPTION
## Description
I renamed the reset_command to shutdown_command to reflect its purpose.

Notably, I changed the signal that's been sent from the server from `"RESET"` to `"SHUTDOWN"`. I'm not sure whether that is the desired behaviour, that's why I added @robertasn as a reviewer. Otherwise the changes should be straight forward.