### PR TITLE
STM: First basic transition test

### DIFF
--- a/test/src/Test.files
+++ b/test/src/Test.files
@@ -4,6 +4,7 @@
 
 T_SRCS := \
   state_machine/dummy.test.cpp \
+  state_machine/transitions.test.cpp \
   utils/config.test.cpp \
   utils/kalman_multivariate.test.cpp \
   utils/integrator.test.cpp \

--- a/test/src/state_machine/transitions.test.cpp
+++ b/test/src/state_machine/transitions.test.cpp
@@ -1,0 +1,72 @@
+/*
+ * Author: QA team
+ * Organisation: HYPED
+ * Date:
+ * Description:
+ *
+ *    Copyright 2019 HYPED
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *    except in compliance with the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *    either express or implied. See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <string>
+
+#include "data/data.hpp"
+#include "gtest/gtest.h"
+#include "state_machine/transitions.hpp"
+#include "utils/logger.hpp"
+
+using namespace hyped::data;
+using namespace hyped::state_machine;
+
+struct TransitionFunctionality : public ::testing::Test {
+  // TODO(miltfra): Disable printing log messages to stdout/stderr
+  hyped::utils::Logger log;
+  const std::string brake_emergency_error    = "Should handle emergency in Embrakes.";
+  const std::string brake_no_emergency_error = "Should handle emergency in Embrakes.";
+
+ protected:
+  void SetUp() {}
+  void TearDown() {}
+};
+
+// Test fixture for 'accelerating' state
+TEST_F(TransitionFunctionality, handlesBrakeEmergency)
+{
+  EmergencyBrakes embrakes_data;
+
+  Navigation nav_data;
+  Batteries batteries_data;
+  Telemetry telemetry_data;
+  Sensors sensors_data;
+  Motors motors_data;
+
+  ModuleStatus other;
+  bool has_emergency;
+  for (int i = 0; static_cast<ModuleStatus>(i) != ModuleStatus::kCriticalFailure; i++) {
+    // Making sure checkEmergency is unaffected by status of other values.
+    other                        = static_cast<ModuleStatus>(i);
+    nav_data.module_status       = other;
+    batteries_data.module_status = other;
+    telemetry_data.module_status = other;
+    sensors_data.module_status   = other;
+    motors_data.module_status    = other;
+    // Checking emergency case
+    embrakes_data.module_status = ModuleStatus::kCriticalFailure;
+    has_emergency = checkEmergency(log, embrakes_data, nav_data, batteries_data, telemetry_data,
+                                   sensors_data, motors_data);
+    ASSERT_EQ(has_emergency, true) << brake_emergency_error;
+    // Checking non-emergency case
+    embrakes_data.module_status = other;
+    has_emergency = checkEmergency(log, embrakes_data, nav_data, batteries_data, telemetry_data,
+                                   sensors_data, motors_data);
+    ASSERT_EQ(has_emergency, false) << brake_no_emergency_error;
+  }
+}


### PR DESCRIPTION
## Description
This is the first basic transition test for State Machine. I've tried to make it as foolproof as possible by using each instance ModuleStatus for each module. Iterating over all the possible combinations seemed a bit unreasonable since it is unlikely that a combination of non-emergency states will cause the emergency not to be recognised.

Additionally, this only contains the *first* test. We will get around to testing all of them once we've made sure that this is generally speaking fine with QA so that we don't write too much unnecessary code.

## Changes
- Created and populated `test/src/state_machine/transitions.test.cpp`
- Added `state_machine/transitions.test.cpp` to `test/src/Test.files`