### PR TITLE
STM: Extracted all transition checks into variables for consistency

### DIFF
--- a/src/state_machine/state.cpp
+++ b/src/state_machine/state.cpp
@@ -165,7 +165,9 @@ State *Finished::checkTransition(Logger &log)
 {
   // We only need to update telemetry data.
   telemetry_data_ = data_.getTelemetryData();
-  if (checkShutdownCommand(log, telemetry_data_)) { return Off::getInstance(); }
+
+  bool received_shutdown_command = checkShutdownCommand(log, telemetry_data_);
+  if (received_shutdown_command) { return Off::getInstance(); }
   return nullptr;
 }
 
@@ -180,8 +182,8 @@ char FailureBraking::string_representation_[] = "FailureBraking";
 State *FailureBraking::checkTransition(Logger &log)
 {
   // We only need to update navigation data.
-  nav_data_    = data_.getNavigationData();
-  
+  nav_data_ = data_.getNavigationData();
+
   bool stopped = checkPodStopped(log, nav_data_);
   if (stopped) { return FailureStopped::getInstance(); }
   return nullptr;
@@ -199,7 +201,9 @@ State *FailureStopped::checkTransition(Logger &log)
 {
   // We only need to update telemetry data.
   telemetry_data_ = data_.getTelemetryData();
-  if (checkShutdownCommand(log, telemetry_data_)) { return Off::getInstance(); }
+
+  bool received_shutdown_command = checkShutdownCommand(log, telemetry_data_);
+  if (received_shutdown_command) { return Off::getInstance(); }
   return nullptr;
 }
 

--- a/src/state_machine/state.cpp
+++ b/src/state_machine/state.cpp
@@ -180,8 +180,10 @@ char FailureBraking::string_representation_[] = "FailureBraking";
 State *FailureBraking::checkTransition(Logger &log)
 {
   // We only need to update navigation data.
-  nav_data_ = data_.getNavigationData();
-  if (checkPodStopped(log, nav_data_)) { return FailureStopped::getInstance(); }
+  nav_data_    = data_.getNavigationData();
+  
+  bool stopped = checkPodStopped(log, nav_data_);
+  if (stopped) { return FailureStopped::getInstance(); }
   return nullptr;
 }
 


### PR DESCRIPTION
Since I've been working on updating the state diagram to accommodate for the new cruising state, I've noticed that there was an inconsistency in naming amongst the `checkTransition` implementations for `NominalBraking` and `FailureBraking`.

This has now been fixed.

The same treatment has been applied to various other transitions.