### PR TITLE
MTC: Fixed main loop logic

### DIFF
--- a/src/data/data.cpp
+++ b/src/data/data.cpp
@@ -24,6 +24,7 @@ using utils::concurrent::ScopedLock;
 
 namespace data {
 
+// TODO(miltfra): Fix string representations
 const char* states[num_states] = {
   "Idle",
   "Calibrating",

--- a/src/propulsion/main.cpp
+++ b/src/propulsion/main.cpp
@@ -85,6 +85,9 @@ void Main::run()
       case State::kAccelerating:
         state_processor_->accelerate();
         break;
+      case State::kCruising:
+        // TODO(Akshath29): Implement cruising behaviour
+        break;
       case State::kNominalBraking:
       case State::kEmergencyBraking:
         state_processor_->quickStopAll();

--- a/src/propulsion/main.cpp
+++ b/src/propulsion/main.cpp
@@ -1,7 +1,7 @@
 /*
- * Author: Gregor Konzett
+ * Author: Gregor Konzett, Franz Miltz
  * Organisation: HYPED
- * Date: 1.4.2019
+ * Date: 13.02.2021
  * Description: Main entrypoint to motor control module
  *
  *    Copyright 2019 HYPED
@@ -18,136 +18,81 @@
 
 #include "propulsion/main.hpp"
 
-namespace hyped
-{
+namespace hyped {
 
-namespace motor_control
-{
+namespace motor_control {
 Main::Main(uint8_t id, Logger &log)
-  : Thread(id, log),
-    is_running_(true),
-    log_(log),
-    state_processor_(new StateProcessor(Motors::kNumMotors, log)),
-    data_(Data::getInstance())
+    : Thread(id, log),
+      is_running_(true),
+      log_(log),
+      state_processor_(new StateProcessor(Motors::kNumMotors, log))
 {
-  // Initialise states
-  current_state_ = data_.getStateMachineData().current_state;
-  previous_state_ = State::kInvalid;
+}
+
+bool Main::handleTransition()
+{
+  if (current_state_ == previous_state_) return false;
+
+  log_.INFO("Motor", "Entered %s state", data::states[current_state_]);
+  return true;
+}
+
+void Main::handleCriticalFailure(Data &data, Motors &motor_data)
+{
+  is_running_              = false;
+  motor_data.module_status = ModuleStatus::kCriticalFailure;
+  data.setMotorData(motor_data);
 }
 
 void Main::run()
 {
-  log_.INFO("Motor", "Thread started");
+  utils::System &sys      = utils::System::getSystem();
+  data::Data &data        = data::Data::getInstance();
+  data::Motors motor_data = data.getMotorData();
 
-  System &sys = System::getSystem();
+  // Initialise states
+  current_state_  = data.getStateMachineData().current_state;
+  previous_state_ = State::kInvalid;
 
-  Motors motor_data = data_.getMotorData();
+  // kInit for SM transition
+  motor_data.module_status = ModuleStatus::kInit;
+  data.setMotorData(motor_data);
+  log_.INFO("Motor", "Initialisation complete");
 
   while (is_running_ && sys.running_) {
     // Get the current state of the system from the state machine's data
-    current_state_ = data_.getStateMachineData().current_state;
+    motor_data                  = data.getMotorData();
+    current_state_              = data.getStateMachineData().current_state;
+    bool encountered_transition = handleTransition();
 
-    if (current_state_ == State::kIdle) {  // Initialize motors
-      if (current_state_ != previous_state_) {
-        log_.INFO("Motor", "State idle");
-        previous_state_ = current_state_;
-      }
-      if (motor_data.module_status != ModuleStatus::kInit) {
-        motor_data.module_status = ModuleStatus::kInit;
-        data_.setMotorData(motor_data);
-      }
-    } else if (current_state_ == State::kCalibrating) {
-        // Calculate slip values
-        if (previous_state_ != current_state_) {
-          log_.INFO("Motor", "State Calibrating");
-          previous_state_ = current_state_;
-        }
-        if (!state_processor_->isInitialized()) {
+    switch (current_state_) {
+      case State::kIdle:
+        break;
+      case State::kCalibrating:
+        if (state_processor_->isInitialized()) {
+          if (motor_data.module_status != ModuleStatus::kReady) {
+            motor_data.module_status = ModuleStatus::kReady;
+            data.setMotorData(motor_data);
+          }
+        } else {
           state_processor_->initMotors();
-          if (state_processor_->isCriticalFailure()) {
-            motor_data.module_status = ModuleStatus::kCriticalFailure;
-            data_.setMotorData(motor_data);
-            is_running_ = false;
-          }
+          if (state_processor_->isCriticalFailure()) { handleCriticalFailure(data, motor_data); }
         }
-        if (state_processor_->isInitialized() && motor_data.module_status != ModuleStatus::kReady) {
-          motor_data.module_status = ModuleStatus::kReady;
-          data_.setMotorData(motor_data);
-        }
-    } else if (current_state_ == State::kReady) {
-          // Standby and wait
-          if (previous_state_ != current_state_) {
-            log_.INFO("Motor", "State Ready");
-            previous_state_ = current_state_;
-            state_processor_->sendOperationalCommand();
-          }
-    } else if (current_state_ == State::kAccelerating) {
-          // Accelerate the motors
-          if (previous_state_ != current_state_) {
-            log_.INFO("Motor", "State Accelerating");
-            previous_state_ = current_state_;
-          }
-          state_processor_->accelerate();
-    } else if (current_state_ == State::kNominalBraking) {
-          // Stop all motors
-          if (previous_state_ != current_state_) {
-            log_.INFO("Motor", "State NominalBraking");
-            previous_state_ = current_state_;
-          }
-          state_processor_->quickStopAll();
-    } else if (current_state_ == State::kEmergencyBraking) {
-          // Stop all motors
-          if (previous_state_ != current_state_) {
-            log_.INFO("Motor", "State EmergencyBraking");
-            previous_state_ = current_state_;
-          }
-          state_processor_->quickStopAll();
-    } else if (current_state_ == State::kExiting) {
-          // Move very slowly out of tube
-          if (previous_state_ != current_state_) {
-            log_.INFO("Motor", "State Exiting");
-            previous_state_ = current_state_;
-          }
-          Telemetry telem = data_.getTelemetryData();
-          if (telem.service_propulsion_go) {
-            state_processor_->servicePropulsion();
-            log_.DBG1("MOTOR", "Service propulsion active");
-          } else {
-            state_processor_->quickStopAll();
-          }
-    } else if (current_state_ == State::kFailureStopped) {
-          // Enter preoperational
-          if (previous_state_ != current_state_) {
-            log_.INFO("Motor", "State FailureStopped");
-            previous_state_ = current_state_;
-          }
-          state_processor_->enterPreOperational();
-    } else if (current_state_ == State::kFinished) {
-          if (previous_state_ != current_state_) {
-            log_.INFO("Motor", "State Finished");
-            previous_state_ = current_state_;
-          }
-          state_processor_->enterPreOperational();
-    } else if (current_state_ == State::kRunComplete) {
-          // Run complete
-          if (previous_state_ != current_state_) {
-            log_.INFO("Motor", "State RunComplete");
-            previous_state_ = current_state_;
-          }
-          state_processor_->quickStopAll();
-    } else {
-          // Unknown State
-          if (previous_state_ != current_state_) {
-            log_.INFO("Motor", "State Unknown");
-            previous_state_ = current_state_;
-          }
-          is_running_ = false;
-          log_.ERR("Motor", "Unknown state");
-          motor_data.module_status = ModuleStatus::kCriticalFailure;
-          data_.setMotorData(motor_data);
-          state_processor_->quickStopAll();
+        break;
+      case State::kReady:
+        if (encountered_transition) { state_processor_->sendOperationalCommand(); }
+        break;
+      case State::kAccelerating:
+        state_processor_->accelerate();
+        break;
+      case State::kNominalBraking:
+      case State::kEmergencyBraking:
+        state_processor_->quickStopAll();
+        break;
+      default:
+        handleCriticalFailure(data, motor_data);
+        break;
     }
-    sleep(1);
   }
 
   log_.INFO("Motor", "Thread shutting down");

--- a/src/propulsion/main.hpp
+++ b/src/propulsion/main.hpp
@@ -19,49 +19,51 @@
 #ifndef PROPULSION_MAIN_HPP_
 #define PROPULSION_MAIN_HPP_
 
-#include "utils/concurrent/thread.hpp"
 #include "utils/concurrent/barrier.hpp"
+#include "utils/concurrent/thread.hpp"
+#include "utils/logger.hpp"
 #include "utils/system.hpp"
 #include "utils/timer.hpp"
-#include "utils/logger.hpp"
 // #include "propulsion/can/can_sender.hpp"
 #include "data/data.hpp"
-
 #include "state_processor.hpp"
 
-namespace hyped
-{
+namespace hyped {
 using data::Data;
-using data::State;
 using data::ModuleStatus;
 using data::Motors;
+using data::State;
 using data::Telemetry;
 using utils::Logger;
 using utils::System;
 using utils::concurrent::Thread;
 
-namespace motor_control
-{
+namespace motor_control {
 
 constexpr int32_t kNumMotors = 4;
 
-class Main : public Thread
-{
-    public:
-        Main(uint8_t id, Logger &log);
+class Main : public Thread {
+ public:
+  Main(uint8_t id, Logger &log);
 
-    /**
-     * @brief {This function is the entrypoint to the propulsion module and reacts to the certain states}
-    * */
-    void run() override;
+  /**
+   * @brief {This function is the entrypoint to the propulsion module and reacts to the certain
+   * states}
+   */
+  void run() override;
 
-  private:
-    bool is_running_;
-    Logger &log_;
-    StateProcessor *state_processor_;
-    State current_state_;
-    State previous_state_;
-    Data& data_;
+ private:
+  bool is_running_;
+  Logger &log_;
+  StateProcessor *state_processor_;
+  State current_state_;
+  State previous_state_;
+  /**
+   * @brief   Returns true iff the pod state has changed since the last check.
+   */
+  bool handleTransition();
+
+  void handleCriticalFailure(Data &data, Motors &motor_data);
 };
 
 }  // namespace motor_control


### PR DESCRIPTION
This fixes the logic in the main loop of propulsion. In particular, the changes are
1. Major refactoring to make everything more readable.
2. Dropped deprecated states, in particular, `kExiting` and `kRunComplete` and thereby eliminated service propulsion.

Note that this is into stm-cruising so you should not be worried about braking develop here.