### PR TITLE
Renamed NavigationType to nav_t

### DIFF
--- a/src/data/data.hpp
+++ b/src/data/data.hpp
@@ -55,16 +55,16 @@ struct Module {
 // -------------------------------------------------------------------------------------------------
 // Navigation
 // -------------------------------------------------------------------------------------------------
-typedef float NavigationType;
-typedef Vector<NavigationType, 3> NavigationVector;
+typedef float nav_t;
+typedef Vector<nav_t, 3> NavigationVector;
 struct Navigation : public Module {
   static constexpr float run_length = 1250;  // m
   static constexpr float braking_buffer = 20; // m
-  NavigationType  displacement;  // m
-  NavigationType  velocity;  // m/s
-  NavigationType  acceleration;  // m/s^2
-  NavigationType  emergency_braking_distance;
-  NavigationType  braking_distance = 750;  // m
+  nav_t  displacement;  // m
+  nav_t  velocity;  // m/s
+  nav_t  acceleration;  // m/s^2
+  nav_t  emergency_braking_distance;
+  nav_t  braking_distance = 750;  // m
 };
 
 // -------------------------------------------------------------------------------------------------
@@ -81,7 +81,7 @@ struct ImuData : public Sensor {
 };
 
 struct EncoderData : public Sensor {
-  NavigationType disp;
+  nav_t disp;
 };
 
 struct StripeCounter : public Sensor {

--- a/src/navigation/imu_data_logger.hpp
+++ b/src/navigation/imu_data_logger.hpp
@@ -30,7 +30,7 @@
 #include "data/data_point.hpp"
 
 namespace hyped {
-using data::NavigationType;
+using data::nav_t;
 using data::NavigationVector;
 using data::DataPoint;
 

--- a/src/navigation/kalman_filter.cpp
+++ b/src/navigation/kalman_filter.cpp
@@ -68,17 +68,17 @@ void KalmanFilter::updateMeasurementCovarianceMatrix(double var)
   kalmanFilter_.updateR(R);
 }
 
-const NavigationType KalmanFilter::filter(NavigationType z)
+const nav_t KalmanFilter::filter(nav_t z)
 {
   VectorXf vz(m_);
   vz(0) = z;
   kalmanFilter_.filter(vz);
 
-  NavigationType estimate = getEstimate();
+  nav_t estimate = getEstimate();
   return estimate;
 }
 
-const NavigationType KalmanFilter::filter(NavigationType u, NavigationType z)
+const nav_t KalmanFilter::filter(nav_t u, nav_t z)
 {
   VectorXf vu(k_);
   vu(0) = u;
@@ -88,7 +88,7 @@ const NavigationType KalmanFilter::filter(NavigationType u, NavigationType z)
 
   kalmanFilter_.filter(vu, vz);
 
-  NavigationType estimate = getEstimate();
+  nav_t estimate = getEstimate();
   return estimate;
 }
 
@@ -155,17 +155,17 @@ const MatrixXf KalmanFilter::createStationaryMeasurementCovarianceMatrix()
   return R;
 }
 
-const NavigationType KalmanFilter::getEstimate()
+const nav_t KalmanFilter::getEstimate()
 {
   VectorXf x = kalmanFilter_.getStateEstimate();
-  NavigationType est = x(0);
+  nav_t est = x(0);
   return est;
 }
 
-const NavigationType KalmanFilter::getEstimateVariance()
+const nav_t KalmanFilter::getEstimateVariance()
 {
   MatrixXf P = kalmanFilter_.getStateCovariance();
-  NavigationType var = P(0, 0);
+  nav_t var = P(0, 0);
   return var;
 }
 

--- a/src/navigation/kalman_filter.hpp
+++ b/src/navigation/kalman_filter.hpp
@@ -30,7 +30,7 @@ using Eigen::MatrixXf;
 using Eigen::VectorXf;
 
 namespace hyped {
-using data::NavigationType;
+using data::nav_t;
 using data::NavigationVector;
 using utils::System;
 using utils::math::KalmanMultivariate;
@@ -44,12 +44,12 @@ class KalmanFilter
     void setup();
     void updateStateTransitionMatrix(double dt);
     void updateMeasurementCovarianceMatrix(double var);
-    const NavigationType filter(NavigationType z);
-    const NavigationType filter(NavigationType u, NavigationType z);
+    const nav_t filter(nav_t z);
+    const nav_t filter(nav_t u, nav_t z);
     // transfer estimate to NavigationVector
-    const NavigationType getEstimate();
+    const nav_t getEstimate();
     // transfer estimate variances to NavigationVector
-    const NavigationType getEstimateVariance();
+    const nav_t getEstimateVariance();
   private:
     unsigned int    n_;
     unsigned int    m_;

--- a/src/navigation/navigation.hpp
+++ b/src/navigation/navigation.hpp
@@ -39,7 +39,7 @@ using data::Data;
 using data::DataPoint;
 using data::ImuData;
 using data::ModuleStatus;
-using data::NavigationType;
+using data::nav_t;
 using data::NavigationVector;
 using data::Motors;
 using data::Sensors;
@@ -57,9 +57,9 @@ namespace navigation {
       typedef array<ImuData, Sensors::kNumImus>                   ImuDataArray;
       typedef DataPoint<ImuDataArray>                             ImuDataPointArray;
       typedef array<NavigationVector, Sensors::kNumImus>          NavigationVectorArray;
-      typedef array<array<NavigationType, Sensors::kNumImus>, 3>  ImuAxisData;
-      typedef array<NavigationType, Sensors::kNumImus>            NavigationArray;
-      typedef array<NavigationType, Sensors::kNumImus-1>          NavigationArrayOneFaulty;
+      typedef array<array<nav_t, Sensors::kNumImus>, 3>  ImuAxisData;
+      typedef array<nav_t, Sensors::kNumImus>            NavigationArray;
+      typedef array<nav_t, Sensors::kNumImus-1>          NavigationArrayOneFaulty;
       typedef array<KalmanFilter, Sensors::kNumImus>              FilterArray;
 
       /**
@@ -78,34 +78,34 @@ namespace navigation {
       /**
        * @brief Get the measured acceleration [m/s^2]
        *
-       * @return NavigationType Returns the forward component of acceleration vector (negative when
+       * @return nav_t Returns the forward component of acceleration vector (negative when
        *                        decelerating) [m/s^2]
        */
-      NavigationType getAcceleration() const;
+      nav_t getAcceleration() const;
       /**
        * @brief Get the measured velocity [m/s]
        *
-       * @return NavigationType Returns the forward component of velocity vector [m/s]
+       * @return nav_t Returns the forward component of velocity vector [m/s]
        */
-      NavigationType getVelocity() const;
+      nav_t getVelocity() const;
       /**
        * @brief Get the measured displacement [m]
        *
-       * @return NavigationType Returns the forward component of displacement vector [m]
+       * @return nav_t Returns the forward component of displacement vector [m]
        */
-      NavigationType getDisplacement() const;
+      nav_t getDisplacement() const;
       /**
        * @brief Get the emergency braking distance [m]
        *
-       * @return NavigationType emergency braking distance [m]
+       * @return nav_t emergency braking distance [m]
        */
-      NavigationType getEmergencyBrakingDistance() const;
+      nav_t getEmergencyBrakingDistance() const;
       /**
        * @brief Get the braking distance [m]
        *
-       * @return NavigationType braking distance [m]
+       * @return nav_t braking distance [m]
        */
-      NavigationType getBrakingDistance() const;
+      nav_t getBrakingDistance() const;
       /**
        * @brief Get the determined gravity calibration [m/s^2]
        *
@@ -169,11 +169,11 @@ namespace navigation {
       static constexpr char kDelimiter = '\t';
 
       static constexpr int kPrintFreq = 1;
-      static constexpr NavigationType kEmergencyDeceleration = 24;
+      static constexpr nav_t kEmergencyDeceleration = 24;
       static constexpr float kTukeyThreshold = 1;  // 0.75
       static constexpr float kTukeyIQRBound = 3;
 
-      static constexpr NavigationType kStripeDistance = 30.48;
+      static constexpr nav_t kStripeDistance = 30.48;
 
       static constexpr uint32_t pod_mass_           = 250;  // kg
       static constexpr float    mom_inertia_wheel_  = 0.04;  // kgm²
@@ -199,7 +199,7 @@ namespace navigation {
       // acceptable variances for calibration measurements: {x, y, z}
       array<float, 3> calibration_limits_;
       // Calibration variances in each dimension, necessary for vibration checking
-      array<NavigationType, 3> calibration_variance_;
+      array<nav_t, 3> calibration_variance_;
 
       // Array of previous measurements
       array<ImuAxisData, kPreviousMeasurements> previous_measurements_;
@@ -223,9 +223,9 @@ namespace navigation {
 
       // To store estimated values
       ImuDataPointArray sensor_readings_;
-      DataPoint<NavigationType> acceleration_;
-      DataPoint<NavigationType> velocity_;
-      DataPoint<NavigationType> displacement_;
+      DataPoint<nav_t> acceleration_;
+      DataPoint<nav_t> velocity_;
+      DataPoint<nav_t> displacement_;
       NavigationVectorArray gravity_calibration_;
 
       // Initial timestamp (for comparisons)
@@ -233,13 +233,13 @@ namespace navigation {
       // Previous timestamp
       uint32_t prev_timestamp_;
       // Uncertainty in distance
-      NavigationType displ_unc_;
+      nav_t displ_unc_;
       // Uncertainty in velocity
-      NavigationType vel_unc_;
+      nav_t vel_unc_;
       // Previous acceleration measurement, necessary for uncertainty determination
-      NavigationType prev_acc_;
+      nav_t prev_acc_;
       // Previous velocity measurement
-      NavigationType prev_vel_;
+      nav_t prev_vel_;
       // Have initial timestamps been set?
       bool init_time_set_;
 
@@ -250,13 +250,13 @@ namespace navigation {
       bool keyence_real_;
 
       // To convert acceleration -> velocity -> distance
-      Integrator<NavigationType> acceleration_integrator_;  // acceleration to velocity
-      Integrator<NavigationType> velocity_integrator_;      // velocity to distance
+      Integrator<nav_t> acceleration_integrator_;  // acceleration to velocity
+      Integrator<nav_t> velocity_integrator_;      // velocity to distance
 
       /**
        * @brief Compute norm of acceleration measurement
        */
-      NavigationType accNorm(NavigationVector& acc);
+      nav_t accNorm(NavigationVector& acc);
       /**
        * @brief Query sensors to determine acceleration, velocity and distance
        */

--- a/src/navigation/stripe_handler.cpp
+++ b/src/navigation/stripe_handler.cpp
@@ -22,8 +22,8 @@
 namespace hyped {
 namespace navigation {
 
-StripeHandler::StripeHandler(Logger& log, Data& data, const NavigationType& displ_unc,
-                             NavigationType& vel_unc, const NavigationType stripe_dist)
+StripeHandler::StripeHandler(Logger& log, Data& data, const nav_t& displ_unc,
+                             nav_t& vel_unc, const nav_t stripe_dist)
     : kStripeDist(stripe_dist),
       log_(log),
       data_(data),
@@ -59,7 +59,7 @@ uint8_t StripeHandler::getFailureCount()
   return n_missed_stripes_;
 }
 
-bool StripeHandler::checkFailure(NavigationType displ)
+bool StripeHandler::checkFailure(nav_t displ)
 {
   // Failure if more than one disagreement
   if (n_missed_stripes_ > 1) {
@@ -73,14 +73,14 @@ bool StripeHandler::checkFailure(NavigationType displ)
   return false;
 }
 
-void StripeHandler::updateNavData(NavigationType& displ, NavigationType& vel)
+void StripeHandler::updateNavData(nav_t& displ, nav_t& vel)
 {
-  NavigationType displ_offset = displ - stripe_counter_.value*kStripeDist;
+  nav_t displ_offset = displ - stripe_counter_.value*kStripeDist;
   vel -= displ_offset*1e6/(stripe_counter_.timestamp - init_time_);
   displ -= displ_offset;
 }
 
-void StripeHandler::queryKeyence(NavigationType& displ, NavigationType& vel, bool real)
+void StripeHandler::queryKeyence(nav_t& displ, nav_t& vel, bool real)
 {
   getReadings();
 
@@ -93,9 +93,9 @@ void StripeHandler::queryKeyence(NavigationType& displ, NavigationType& vel, boo
     stripe_counter_.timestamp = readings_[i].count.timestamp;
     if (!real) stripe_counter_.timestamp = utils::Timer::getTimeMicros();
 
-    NavigationType minimum_uncertainty = kStripeDist / 5.;
-    NavigationType allowed_uncertainty = std::max(displ_unc_, minimum_uncertainty);
-    NavigationType displ_offset = displ - stripe_counter_.value*kStripeDist;
+    nav_t minimum_uncertainty = kStripeDist / 5.;
+    nav_t allowed_uncertainty = std::max(displ_unc_, minimum_uncertainty);
+    nav_t displ_offset = displ - stripe_counter_.value*kStripeDist;
 
     // Allow up to one missed stripe
     if (displ_offset > kStripeDist - allowed_uncertainty &&

--- a/src/navigation/stripe_handler.hpp
+++ b/src/navigation/stripe_handler.hpp
@@ -34,7 +34,7 @@ namespace hyped {
 using data::Data;
 using data::DataPoint;
 using data::ModuleStatus;
-using data::NavigationType;
+using data::nav_t;
 using data::NavigationVector;
 using data::Motors;
 using data::Sensors;
@@ -56,8 +56,8 @@ class StripeHandler {
    * @param vel_unc Reference to uncertainty in velocity, this is written to
    * @param stripe_dist Distance between two stripes
    */
-  explicit StripeHandler(Logger& log, Data& data, const NavigationType& displ_unc,
-                         NavigationType& vel_unc, const NavigationType stripe_dist);
+  explicit StripeHandler(Logger& log, Data& data, const nav_t& displ_unc,
+                         nav_t& vel_unc, const nav_t stripe_dist);
 
   /**
    * @brief Check if stripe has been detected and changes the displacement
@@ -67,7 +67,7 @@ class StripeHandler {
    * @param vel Current velocity
    * @param real Whether or not the sensors are real
    */
-  void queryKeyence(NavigationType& displ, NavigationType& vel, bool real);
+  void queryKeyence(nav_t& displ, nav_t& vel, bool real);
   /**
    * @brief Checks if submodule should enter kCriticalFailure
    *
@@ -75,7 +75,7 @@ class StripeHandler {
    *
    * @return bool to enter kCriticalFailure or not
    */
-  bool checkFailure(NavigationType displ);
+  bool checkFailure(nav_t displ);
   /**
    * @brief Sets the initial time and keyence data
    *        Occurs on the first iteration when nav-
@@ -99,7 +99,7 @@ class StripeHandler {
 
  private:
   // Distance between stripes
-  const NavigationType kStripeDist;
+  const nav_t kStripeDist;
 
   /**
    * @brief Update nav data
@@ -107,7 +107,7 @@ class StripeHandler {
    * @param displ Current displacement
    * @param vel Current velocity
    */
-  void updateNavData(NavigationType& displ, NavigationType& vel);
+  void updateNavData(nav_t& displ, nav_t& vel);
   /**
    * @brief update prev_readings
    */
@@ -131,9 +131,9 @@ class StripeHandler {
   uint8_t n_missed_stripes_;
 
   // displacement uncertainty, const because this is never written to
-  const NavigationType& displ_unc_;
+  const nav_t& displ_unc_;
   // velocity uncertainty
-  NavigationType& vel_unc_;
+  nav_t& vel_unc_;
   // initial timestamp
   uint32_t init_time_;
 };

--- a/src/sensors/fake_imu.cpp
+++ b/src/sensors/fake_imu.cpp
@@ -239,7 +239,7 @@ NavigationVector FakeImuFromFile::addNoiseToData(NavigationVector value, float n
   static std::default_random_engine generator;
 
   for (int i = 0; i < 3; i++) {
-    std::normal_distribution<NavigationType> distribution(value[i], noise);
+    std::normal_distribution<nav_t> distribution(value[i], noise);
     temp[i] = distribution(generator);
   }
   return temp;

--- a/src/sensors/fake_imu.hpp
+++ b/src/sensors/fake_imu.hpp
@@ -30,7 +30,7 @@ namespace hyped {
 
 using data::ImuData;
 using data::DataPoint;
-using data::NavigationType;
+using data::nav_t;
 using data::NavigationVector;
 
 namespace sensors {

--- a/test/src/state_machine/transitions.test.cpp
+++ b/test/src/state_machine/transitions.test.cpp
@@ -747,15 +747,14 @@ TEST_F(TransitionFunctionality, handlesEnoughSpaceLeft)
   constexpr int max_braking_distance
     = static_cast<int>(nav_data.run_length - nav_data.braking_buffer);
 
-  std::vector<NavigationType> displacements, braking_distances;
+  std::vector<nav_t> displacements, braking_distances;
   for (int i = 0; i < TEST_SIZE; i++) {
     nav_data.braking_distance
-      = static_cast<NavigationType>(randomInRange(min_braking_distance, max_braking_distance));
+      = static_cast<nav_t>(randomInRange(min_braking_distance, max_braking_distance));
     max_displacement = nav_data.run_length - nav_data.braking_buffer - nav_data.braking_distance;
-    nav_data.displacement
-      = static_cast<NavigationType>(randomInRange(min_displacement, max_displacement));
-    nav_data.velocity                   = static_cast<NavigationType>(rand());
-    nav_data.acceleration               = nav_data.velocity;
+    nav_data.displacement = static_cast<nav_t>(randomInRange(min_displacement, max_displacement));
+    nav_data.velocity     = static_cast<nav_t>(rand());
+    nav_data.acceleration = nav_data.velocity;
     nav_data.emergency_braking_distance = nav_data.velocity;
 
     ASSERT_EQ(false, checkEnteredBrakingZone(log, nav_data)) << braking_zone_false_positive_error;
@@ -780,20 +779,19 @@ TEST_F(TransitionFunctionality, handlesNotEnoughSpaceLeft)
 
   for (int i = 0; i < TEST_SIZE; i++) {
     nav_data.braking_distance
-      = static_cast<NavigationType>(randomInRange(min_braking_distance, max_braking_distance));
+      = static_cast<nav_t>(randomInRange(min_braking_distance, max_braking_distance));
     min_displacement = nav_data.run_length - nav_data.braking_buffer - nav_data.braking_distance;
-    nav_data.displacement
-      = static_cast<NavigationType>(randomInRange(min_displacement, max_displacement));
-    nav_data.velocity                   = static_cast<NavigationType>(rand());
-    nav_data.acceleration               = static_cast<NavigationType>(rand());
-    nav_data.emergency_braking_distance = static_cast<NavigationType>(rand());
+    nav_data.displacement = static_cast<nav_t>(randomInRange(min_displacement, max_displacement));
+    nav_data.velocity     = static_cast<nav_t>(rand());
+    nav_data.acceleration = static_cast<nav_t>(rand());
+    nav_data.emergency_braking_distance = static_cast<nav_t>(rand());
 
     ASSERT_EQ(true, checkEnteredBrakingZone(log, nav_data)) << braking_zone_false_negative_error;
   }
 }
 
 /**
- * Let d be the first displacement within the precision of NavigationType that leads to
+ * Let d be the first displacement within the precision of nav_t that leads to
  * checkEnteredBrakingZone returning true. Then this test aims to test values in the interval
  * [d-0.5,d+0.5) to make sure that checkEnteredBrakingZone behaves correctly in this edge case.
  *
@@ -804,21 +802,20 @@ TEST_F(TransitionFunctionality, handlesNotEnoughSpaceLeft)
 TEST_F(TransitionFunctionality, handlesDisplacementOnEdgeOfBrakingZone)
 {
   Navigation nav_data;
-  NavigationType critical_displacement;
+  nav_t critical_displacement;
 
   constexpr int min_braking_distance = 0;
   constexpr int max_braking_distance = nav_data.run_length;
-  constexpr NavigationType step_size = 1.0 / static_cast<NavigationType>(TEST_SIZE);
+  constexpr nav_t step_size          = 1.0 / static_cast<nav_t>(TEST_SIZE);
 
   for (int i = 0; i < TEST_SIZE; i++) {
     nav_data.braking_distance
-      = static_cast<NavigationType>(randomInRange(min_braking_distance, max_braking_distance));
+      = static_cast<nav_t>(randomInRange(min_braking_distance, max_braking_distance));
     critical_displacement
       = nav_data.run_length - nav_data.braking_buffer - nav_data.braking_distance;
 
     for (int j = 0; j < TEST_SIZE; j++) {
-      nav_data.displacement
-        = critical_displacement - 0.5 + step_size * static_cast<NavigationType>(j);
+      nav_data.displacement = critical_displacement - 0.5 + step_size * static_cast<nav_t>(j);
       if (j < TEST_SIZE / 2) {
         ASSERT_EQ(false, checkEnteredBrakingZone(log, nav_data))
           << braking_zone_false_positive_error;
@@ -831,7 +828,7 @@ TEST_F(TransitionFunctionality, handlesDisplacementOnEdgeOfBrakingZone)
 }
 
 /**
- * Let b be the first braking distance within the precision of NavigationType that leads to
+ * Let b be the first braking distance within the precision of nav_t that leads to
  * checkEnteredBrakingZone returning true. Then this test aims to test values in the interval
  * [b-0.5,b+0.5) to make sure that checkEnteredBrakingZone behaves correctly in this edge case.
  *
@@ -842,21 +839,20 @@ TEST_F(TransitionFunctionality, handlesDisplacementOnEdgeOfBrakingZone)
 TEST_F(TransitionFunctionality, handlesBrakingDistanceOnEdgeOfBrakingZone)
 {
   Navigation nav_data;
-  NavigationType critical_braking_distance;
+  nav_t critical_braking_distance;
 
-  constexpr int min_displacement     = 0;
-  constexpr int max_displacement     = nav_data.run_length - nav_data.braking_buffer - 1;
-  constexpr NavigationType step_size = 1.0 / static_cast<NavigationType>(TEST_SIZE);
+  constexpr int min_displacement = 0;
+  constexpr int max_displacement = nav_data.run_length - nav_data.braking_buffer - 1;
+  constexpr nav_t step_size      = 1.0 / static_cast<nav_t>(TEST_SIZE);
 
   for (int i = 0; i < TEST_SIZE; i++) {
-    nav_data.displacement
-      = static_cast<NavigationType>(randomInRange(min_displacement, max_displacement));
+    nav_data.displacement = static_cast<nav_t>(randomInRange(min_displacement, max_displacement));
     critical_braking_distance
       = nav_data.run_length - nav_data.braking_buffer - nav_data.displacement;
 
     for (int j = 0; j < TEST_SIZE; j++) {
       nav_data.braking_distance
-        = critical_braking_distance - 0.5 + step_size * static_cast<NavigationType>(j);
+        = critical_braking_distance - 0.5 + step_size * static_cast<nav_t>(j);
       if (j < TEST_SIZE / 2) {
         ASSERT_EQ(false, checkEnteredBrakingZone(log, nav_data))
           << braking_zone_false_positive_error;
@@ -879,16 +875,15 @@ TEST_F(TransitionFunctionality, handlesPositiveVelocity)
   Navigation nav_data;
 
   constexpr int max_velocity = 100;  // 100 m/s is pretty fast...
-  constexpr NavigationType step_size
-    = static_cast<NavigationType>(max_velocity) / static_cast<NavigationType>(TEST_SIZE);
+  constexpr nav_t step_size  = static_cast<nav_t>(max_velocity) / static_cast<nav_t>(TEST_SIZE);
 
   for (int i = 1; i <= TEST_SIZE; i++) {
-    nav_data.velocity = step_size * static_cast<NavigationType>(i);
+    nav_data.velocity = step_size * static_cast<nav_t>(i);
 
-    nav_data.acceleration               = static_cast<NavigationType>(rand());
-    nav_data.displacement               = static_cast<NavigationType>(rand());
-    nav_data.braking_distance           = static_cast<NavigationType>(rand());
-    nav_data.emergency_braking_distance = static_cast<NavigationType>(rand());
+    nav_data.acceleration               = static_cast<nav_t>(rand());
+    nav_data.displacement               = static_cast<nav_t>(rand());
+    nav_data.braking_distance           = static_cast<nav_t>(rand());
+    nav_data.emergency_braking_distance = static_cast<nav_t>(rand());
 
     ASSERT_EQ(false, checkPodStopped(log, nav_data)) << pod_stopped_false_positive_error;
   }
@@ -905,16 +900,15 @@ TEST_F(TransitionFunctionality, handlesNonpositiveVelocity)
   Navigation nav_data;
 
   constexpr int max_velocity = 100;  // 100 m/s is pretty fast...
-  constexpr NavigationType step_size
-    = static_cast<NavigationType>(max_velocity) / static_cast<NavigationType>(TEST_SIZE);
+  constexpr nav_t step_size  = static_cast<nav_t>(max_velocity) / static_cast<nav_t>(TEST_SIZE);
 
   for (int i = 0; i < TEST_SIZE; i++) {
-    nav_data.velocity = -1.0 * step_size * static_cast<NavigationType>(i);
+    nav_data.velocity = -1.0 * step_size * static_cast<nav_t>(i);
 
-    nav_data.acceleration               = static_cast<NavigationType>(rand());
-    nav_data.displacement               = static_cast<NavigationType>(rand());
-    nav_data.braking_distance           = static_cast<NavigationType>(rand());
-    nav_data.emergency_braking_distance = static_cast<NavigationType>(rand());
+    nav_data.acceleration               = static_cast<nav_t>(rand());
+    nav_data.displacement               = static_cast<nav_t>(rand());
+    nav_data.braking_distance           = static_cast<nav_t>(rand());
+    nav_data.emergency_braking_distance = static_cast<nav_t>(rand());
 
     ASSERT_EQ(true, checkPodStopped(log, nav_data)) << pod_stopped_false_negative_error;
   }


### PR DESCRIPTION
As discussed in todays meeting, I'd like to propose renaming `NavigationType` to `nav_t`. This is
1. More efficient in terms of space, and
2. more in line with naming conventions (lie `int8_t`, `size_t`, ...).