### PR TITLE
STM: Undefining MAKE_STATE macro following Google styleguide

### DIFF
--- a/src/state_machine/state.hpp
+++ b/src/state_machine/state.hpp
@@ -110,6 +110,8 @@ MAKE_STATE(FailureBraking)  // Entered upon failure during the run
 MAKE_STATE(FailureStopped)  // Entered upon failure before the run or after
                             // FailureBraking
 
+#undef MAKE_STATE
+
 // We need to implement Off separately because it works a bit differently
 class Off : public State {
  public:


### PR DESCRIPTION
Examining the Google style-guide I've noticed that it's encouraged to undefine macros once they're not required anymore. State machine only uses one macro at the moment so I've undefined it here.