### PR TITLE
[WIP] QA: Update Makefile to support Production Tests

### DIFF
--- a/utils/build/test.mk
+++ b/utils/build/test.mk
@@ -45,13 +45,16 @@ STATIC_ENABLE=
 
 .PHONY: test
 test: $(T_TARGET)
-	$(Verb) ./$< --gtest_filter=-*_noci
-
-test-all: $(T_TARGET)
 	$(Verb) ./$<
+
+test-essential: $(T_TARGET)
+	$(Verb) ./$< --gtest_filter=-*_prod
 
 test-filter: $(T_TARGET)
 	$(Verb) ./$< --gtest_filter=$(GTEST_FILTERS)
+
+test-production: $(T_TARGET)
+	$(Verb) ./$< --gtest_filter=*_prod
 
 coverage: test
 	$(Verb) ./test/utils/get_code_cov.sh

--- a/utils/build/test.mk
+++ b/utils/build/test.mk
@@ -47,12 +47,15 @@ STATIC_ENABLE=
 test: $(T_TARGET)
 	$(Verb) ./$<
 
+.PHONY: test-essential
 test-essential: $(T_TARGET)
 	$(Verb) ./$< --gtest_filter=-*_prod
 
+.PHONY: test-filter
 test-filter: $(T_TARGET)
 	$(Verb) ./$< --gtest_filter=$(GTEST_FILTERS)
 
+.PHONY: test-production
 test-production: $(T_TARGET)
 	$(Verb) ./$< --gtest_filter=*_prod
 

--- a/utils/githooks/pre-commit
+++ b/utils/githooks/pre-commit
@@ -19,7 +19,8 @@ set -x
 make "$OPTION"
 
 # compile and link, lint on test/src
-make test test-lint $OPTION
+make test-essential
+make test-lint $OPTION
 
 # run static analyzer on src test/src
 # make static # off for now

--- a/utils/githooks/pre-push
+++ b/utils/githooks/pre-push
@@ -16,7 +16,7 @@ fi
 set -x
 
 # run tests
-make test "$OPTION"
+make test-essential "$OPTION"
 
 # Linter checks
 make lintall


### PR DESCRIPTION
## Description
Alters the make commands for testing. We now have a new category of tests called Production tests. These are tests that are may take a long time to execute such as a test simulating the pod running. These tests are going to be excluded from the githooks which will be beneficial when the testing coverage becomes larger

Do not merge before style guide and wiki updates

## Changes
- Removed make test-all. The functionality has been moved to make test (includes static testing)
- Added make test-essential. Runs tests that are not marked as essential
- Added make test-production. Runs exclusively the productions. 
 
## Additional Info
The pull request was opened to remove the Quaternion commits as this created some issues with the Quaternion pull request
The make command names are still subject to change. QA is going to discuss them at the meeting on 22nd February
Feedback on the commands is very much welcome, I am debating whether make test should be for essential tests or all tests.  