### PR TITLE
STM: Fixed error messages during testing

### DIFF
--- a/test/src/state_machine/transitions.test.cpp
+++ b/test/src/state_machine/transitions.test.cpp
@@ -93,6 +93,8 @@ struct TransitionFunctionality : public ::testing::Test {
     fflush(stdout);
     stdout_f     = dup(1);
     tmp_stdout_f = open("/dev/null", O_WRONLY);
+    // Not on Unix, try Windows
+    if (tmp_stdout_f == -1) { tmp_stdout_f = open("nul", O_WRONLY); }
     dup2(tmp_stdout_f, 1);
     close(tmp_stdout_f);
   }

--- a/test/src/state_machine/transitions.test.cpp
+++ b/test/src/state_machine/transitions.test.cpp
@@ -16,8 +16,10 @@
  *    limitations under the License.
  */
 
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 
 #include <string>
 #include <vector>
@@ -45,8 +47,8 @@ struct TransitionFunctionality : public ::testing::Test {
 
   hyped::utils::Logger log;
   static constexpr size_t BUFFER_SIZE = 1024;
-  char stdout_buffer_[BUFFER_SIZE];
-  char stderr_buffer_[BUFFER_SIZE];
+  int stdout_f;
+  int tmp_stdout_f;
 
   // ---- Error messages -------
 
@@ -91,17 +93,17 @@ struct TransitionFunctionality : public ::testing::Test {
  protected:
   void SetUp()
   {
-    // Redirect output and overwrite output buffer
-    freopen("/dev/null", "a", stdout);
-    freopen("/dev/null", "a", stderr);
-    setbuf(stdout, stdout_buffer_);
-    setbuf(stderr, stderr_buffer_);
+    fflush(stdout);
+    stdout_f     = dup(1);
+    tmp_stdout_f = open("/dev/null", O_WRONLY);
+    dup2(tmp_stdout_f, 1);
+    close(tmp_stdout_f);
   }
   void TearDown()
   {
-    // Restore output files (UNIX only!)
-    freopen("/dev/tty", "a", stdout);
-    freopen("/dev/tty", "a", stderr);
+    fflush(stdout);
+    dup2(stdout_f, 1);
+    close(stdout_f);
   }
 };
 

--- a/test/src/state_machine/transitions.test.cpp
+++ b/test/src/state_machine/transitions.test.cpp
@@ -46,7 +46,6 @@ struct TransitionFunctionality : public ::testing::Test {
   // ---- Logger ---------------
 
   hyped::utils::Logger log;
-  static constexpr size_t BUFFER_SIZE = 1024;
   int stdout_f;
   int tmp_stdout_f;
 
@@ -99,6 +98,7 @@ struct TransitionFunctionality : public ::testing::Test {
     dup2(tmp_stdout_f, 1);
     close(tmp_stdout_f);
   }
+
   void TearDown()
   {
     fflush(stdout);

--- a/test/src/state_machine/transitions.test.cpp
+++ b/test/src/state_machine/transitions.test.cpp
@@ -17,9 +17,7 @@
  */
 
 #include <fcntl.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <sys/stat.h>
 
 #include <string>
 #include <vector>

--- a/test/src/state_machine/transitions.test.cpp
+++ b/test/src/state_machine/transitions.test.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 
 #include <string>
@@ -43,6 +44,9 @@ struct TransitionFunctionality : public ::testing::Test {
   // ---- Logger ---------------
 
   hyped::utils::Logger log;
+  static constexpr size_t BUFFER_SIZE = 1024;
+  char stdout_buffer_[BUFFER_SIZE];
+  char stderr_buffer_[BUFFER_SIZE];
 
   // ---- Error messages -------
 
@@ -85,8 +89,20 @@ struct TransitionFunctionality : public ::testing::Test {
   int randomInRange(int, int);
 
  protected:
-  void SetUp() {}
-  void TearDown() {}
+  void SetUp()
+  {
+    // Redirect output and overwrite output buffer
+    freopen("/dev/null", "a", stdout);
+    freopen("/dev/null", "a", stderr);
+    setbuf(stdout, stdout_buffer_);
+    setbuf(stderr, stderr_buffer_);
+  }
+  void TearDown()
+  {
+    // Restore output files (UNIX only!)
+    freopen("/dev/tty", "a", stdout);
+    freopen("/dev/tty", "a", stderr);
+  }
 };
 
 int TransitionFunctionality::randomInRange(int min, int max)

--- a/test/src/state_machine/transitions.test.cpp
+++ b/test/src/state_machine/transitions.test.cpp
@@ -93,8 +93,6 @@ struct TransitionFunctionality : public ::testing::Test {
     fflush(stdout);
     stdout_f     = dup(1);
     tmp_stdout_f = open("/dev/null", O_WRONLY);
-    // Not on Unix, try Windows
-    if (tmp_stdout_f == -1) { tmp_stdout_f = open("nul", O_WRONLY); }
     dup2(tmp_stdout_f, 1);
     close(tmp_stdout_f);
   }


### PR DESCRIPTION
Since the logger is using `fprintf` to `stdout` we have to get our hands dirty and swap out the output file for testing. I'm honestly not sure how this behaves on Windows but it works on Linux (and other Unix-based systems, too).

If anyone has a better idea about how to approach this, let me know!