### PR TITLE
NAV: Handling kCruising and removed deprecated states

### DIFF
--- a/src/navigation/main.cpp
+++ b/src/navigation/main.cpp
@@ -63,9 +63,8 @@ namespace navigation {
            }
 
         case State::kNominalBraking :
+        case State::kCruising :
         case State::kEmergencyBraking :
-        case State::kExiting :
-        case State::kRunComplete :
           nav_.navigate();
           break;
 


### PR DESCRIPTION
## Description

A small change in the navigation main loop to handle `kCruising`. Further, `kExiting` and `kRunComplete` have been removed in line with the current iteration of STM.