### PR TITLE
EMB: Handling kCruising

### DIFF
--- a/src/embrakes/main.cpp
+++ b/src/embrakes/main.cpp
@@ -85,6 +85,7 @@ void Main::run()
         brake_1->checkHome();
         break;
       case data::State::kAccelerating:
+      case data::State::kCruising:
         brake_1->checkAccFailure();
         break;
       case data::State::kNominalBraking:


### PR DESCRIPTION
## Description
Embrakes now behave in `kCruising` the exact same way they do in `kAccelerating`.