### PR TITLE
TLM: Updated logic to match state machine

### DIFF
--- a/src/telemetry/main.cpp
+++ b/src/telemetry/main.cpp
@@ -69,7 +69,7 @@ void Main::run()
   }
 
 
-  telem_data_struct.module_status = ModuleStatus::kInit;
+  telem_data_struct.module_status = ModuleStatus::kReady;
   data_.setTelemetryData(telem_data_struct);
 
   SendLoop sendloop_thread {log_, data_, this};

--- a/src/telemetry/main.cpp
+++ b/src/telemetry/main.cpp
@@ -44,16 +44,17 @@ void Main::run()
 {
   // check if telemetry is disabled
   hyped::utils::System& sys = hyped::utils::System::getSystem();
+  data::Telemetry telem_data_struct = data_.getTelemetryData();
+
   if (sys.telemetry_off) {
     log_.DBG("Telemetry", "Telemetry is disabled");
     log_.DBG("Telemetry", "Exiting Telemetry Main thread");
+    telem_data_struct.module_status = ModuleStatus::kReady;
+    data_.setTelemetryData(telem_data_struct);
     return;
   }
 
   log_.DBG("Telemetry", "Telemetry Main thread started");
-
-  data::Telemetry telem_data_struct = data_.getTelemetryData();
-
 
   try {
     client_->connect();
@@ -67,7 +68,6 @@ void Main::run()
 
     return;
   }
-
 
   telem_data_struct.module_status = ModuleStatus::kReady;
   data_.setTelemetryData(telem_data_struct);

--- a/src/telemetry/writer.cpp
+++ b/src/telemetry/writer.cpp
@@ -177,18 +177,16 @@ const char* Writer::convertStateMachineState(data::State state)
       return "IDLE";
     case data::State::kCalibrating:
       return "CALIBRATING";
-    case data::State::kRunComplete:
-      return "RUN_COMPLETE";
     case data::State::kFinished:
       return "FINISHED";
     case data::State::kReady:
       return "READY";
     case data::State::kAccelerating:
       return "ACCELERATING";
+    case data::State::kCruising:
+      return "CRUISING";
     case data::State::kNominalBraking:
       return "NOMINAL_BRAKING";
-    case data::State::kExiting:
-      return "EXITING";
     default:
       return "";
     }


### PR DESCRIPTION
The changes are:
1. Removing the deprecated states `kRunComplete` and `kExiting`
2. Added `kCruising` to `Writer::convertStateMachineState`
3. Set `kReady` instead of `kInit` on startup.

Please make sure these changes are both *correct* and *complete*, i.e. telemetry now fully follows the guidelines given by STM.