### PR TITLE
[WIP] SNS: Updated logic to match state machine

### DIFF
--- a/src/embrakes/main.cpp
+++ b/src/embrakes/main.cpp
@@ -105,6 +105,7 @@ void Main::run()
         f_brake_->checkAccFailure();
         break;
       case data::State::kAccelerating:
+      case data::State::kCruising:
         m_brake_->checkAccFailure();
         f_brake_->checkAccFailure();
         break;

--- a/src/embrakes/main.cpp
+++ b/src/embrakes/main.cpp
@@ -109,19 +109,6 @@ void Main::run()
         f_brake_->checkAccFailure();
         break;
       case data::State::kNominalBraking:
-        if (!m_brake_->checkClamped()) {
-          m_brake_->sendClamp();
-        }
-        if (!f_brake_->checkClamped()) {
-          f_brake_->sendClamp();
-        }
-        Thread::sleep(em_brakes_.brake_command_wait_time);
-        m_brake_->checkHome();
-        f_brake_->checkHome();
-
-        m_brake_->checkBrakingFailure();
-        f_brake_->checkBrakingFailure();
-        break;
       case data::State::kEmergencyBraking:
         if (!m_brake_->checkClamped()) {
           m_brake_->sendClamp();


### PR DESCRIPTION
This is part of the changes required to make #37 work.

The changes so far are:
- (Em-)brakes: Add `kCruising` and merge `kNominalBraking` with `kEmergencyBraking`

Remaining questions:
- What is the [default behaviou](https://www.tutorialspoint.com/cplusplus/cpp_switch_statement.htm)r for these [switches](https://github.com/Hyp-ed/hyped-2021/blob/c8fc9a3c5fb1b70c32b86b00ff639a597641fa38/src/sensors/gpio_manager.cpp#L82-L116)? It's currently missing which leads to (a) compiler warnings and (b) potentially undesired behaviour. If no other cases can occur, we probably want to throw a critical failure if they do. If we want to skip other cases we could use some classic `default: break;`
- Most of the things related to STM in sensors seems to be part of the fake system. Unfortunately, I don't have a clue how this works and what we might need to change. @Videosquared and @hur maybe you can have a look at this? (Search in `src/sensors` for `kAccelerating`, then you'll see what I mean.) Also, try and give me an ELI5. :)

Maybe @robertasn can add to this as well? Afaik, telemetry requires the fake system to work to do tests so it may be in their interest to not brake it.