### PR TITLE
SNS: Logic changes for sensors

### DIFF
--- a/src/sensors/bms_manager.cpp
+++ b/src/sensors/bms_manager.cpp
@@ -76,7 +76,7 @@ BmsManager::BmsManager(Logger& log)
 
   // kInit for SM transition
   batteries_ = data_.getBatteriesData();
-  batteries_.module_status = data::ModuleStatus::kInit;
+  batteries_.module_status = data::ModuleStatus::kReady;
   data_.setBatteriesData(batteries_);
   Thread::yield();
   start_time_ = utils::Timer::getTimeMicros();

--- a/src/sensors/bms_manager.cpp
+++ b/src/sensors/bms_manager.cpp
@@ -76,7 +76,7 @@ BmsManager::BmsManager(Logger& log)
 
   // kInit for SM transition
   batteries_ = data_.getBatteriesData();
-  batteries_.module_status = data::ModuleStatus::kReady;
+  batteries_.module_status = data::ModuleStatus::kInit;
   data_.setBatteriesData(batteries_);
   Thread::yield();
   start_time_ = utils::Timer::getTimeMicros();
@@ -97,6 +97,8 @@ bool BmsManager::checkIMD()
 void BmsManager::run()
 {
   while (sys_.running_) {
+    batteries_ = data_.getBatteriesData();
+
     // keep updating data_ based on values read from sensors
     for (int i = 0; i < data::Batteries::kNumLPBatteries; i++) {
       bms_[i]->getData(&batteries_.low_power_batteries[i]);
@@ -109,7 +111,6 @@ void BmsManager::run()
         batteries_.high_power_batteries[i].voltage = 0;
     }
 
-    /*  THIS HAS TO WORK LATER pls
     if (utils::Timer::getTimeMicros() - start_time_ > check_time_) {
       // check health of batteries
       if (batteries_.module_status != data::ModuleStatus::kCriticalFailure) {
@@ -121,7 +122,6 @@ void BmsManager::run()
         previous_status_ = batteries_.module_status;
       }
     }
-    */
 
     // publish the new data
     data_.setBatteriesData(batteries_);

--- a/src/sensors/gpio_manager.cpp
+++ b/src/sensors/gpio_manager.cpp
@@ -84,9 +84,11 @@ void GpioManager::run()
         case data::ModuleStatus::kCriticalFailure:
           clearHP();
           log_.ERR("GPIO-MANAGER", "Battery Failure! HP SSR cleared");
+          break;
         case data::ModuleStatus::kReady:
           setHP();
           log_.ERR("GPIO-MANAGER", "Module Status kReady! HP SSR set");
+          break;
         default: // default case to indicate non-action explicitly
           break;
       }
@@ -103,12 +105,15 @@ void GpioManager::run()
         case data::State::kFailureStopped:
           clearHP();
           log_.ERR("GPIO-MANAGER", "Emergency State! HP SSR cleared");
+          break;
         case data::State::kFinished:
           clearHP();
           log_.INFO("GPIO-MANAGER", "kFinished reached...HP off");
+          break;
         case data::State::kReady:
           setHP();
           log_.INFO("GPIO-MANAGER", "kReady...HP SSR set and HP on");
+          break;
         default:      // undefied behaviour, e.g. kInvalid
           clearHP();  // shutting down HP asap
           log_.ERR("GPIO-MANAGER", "Unknown State! HP SSR cleared, shutting down!");
@@ -117,6 +122,7 @@ void GpioManager::run()
           data::Batteries batteries_data = data_.getBatteriesData();
           batteries_data.module_status = data::ModuleStatus::kCriticalFailure;
           data_.setBatteriesData(batteries_data);
+          break;
       }
     }
     previous_battery_status_ = battery_status;


### PR DESCRIPTION
Aims to fix the logic to work with the current state machine.

The changes are:
- default behaviour in GPIO manager
- explicit non-action for certain state machine states in GPIO manager
- merged behaviour for `kEmergencyBraking` and `kFailureStopped` as it was identical
- added `break` statements which I believe are intended; **please confirm this is the case**
- changed initial state for batteries to `kReady` in line with state machine

Extends #37 