### PR TITLE
Fixed naming of constants in data

### DIFF
--- a/src/data/data.hpp
+++ b/src/data/data.hpp
@@ -58,13 +58,13 @@ struct Module {
 typedef float nav_t;
 typedef Vector<nav_t, 3> NavigationVector;
 struct Navigation : public Module {
-  static constexpr float run_length = 1250;  // m
-  static constexpr float braking_buffer = 20;  // m
-  nav_t  displacement;  // m
-  nav_t  velocity;  // m/s
-  nav_t  acceleration;  // m/s^2
-  nav_t  emergency_braking_distance;
-  nav_t  braking_distance = 750;  // m
+  static constexpr nav_t kRunLength     = 1250.0;  // m
+  static constexpr nav_t kBrakingBuffer = 20.0;    // m
+  nav_t  displacement;                             // m
+  nav_t  velocity;                                 // m/s
+  nav_t  acceleration;                             // m/s^2
+  nav_t  emergency_braking_distance;               // m
+  nav_t  braking_distance = 750;                   // m
 };
 
 // -------------------------------------------------------------------------------------------------

--- a/src/data/data.hpp
+++ b/src/data/data.hpp
@@ -127,7 +127,7 @@ struct Batteries : public Module {
 };
 
 struct EmergencyBrakes : public Module {
-  static constexpr int brake_command_wait_time = 1000;    // milliseconds
+  static constexpr int kBrakeCommandWaitTime   = 1000;    // milliseconds
   static constexpr int kNumEmbrakes            = 2;
   bool brakes_retracted[kNumEmbrakes]          = {false};  // true if brakes retract
 };

--- a/src/embrakes/main.cpp
+++ b/src/embrakes/main.cpp
@@ -63,7 +63,7 @@ void Main::run()
           if (!f_brake_->checkClamped()) {
             f_brake_->sendClamp();
           }
-          Thread::sleep(em_brakes_.brake_command_wait_time);
+          Thread::sleep(data::EmergencyBrakes::kBrakeCommandWaitTime);
           m_brake_->checkHome();
           f_brake_->checkHome();
 
@@ -77,7 +77,7 @@ void Main::run()
             f_brake_->sendRetract();
           }
 
-          Thread::sleep(em_brakes_.brake_command_wait_time);
+          Thread::sleep(data::EmergencyBrakes::kBrakeCommandWaitTime);
           m_brake_->checkHome();
           f_brake_->checkHome();
 
@@ -98,7 +98,7 @@ void Main::run()
           data_.setEmergencyBrakesData(em_brakes_);
         }
 
-        Thread::sleep(em_brakes_.brake_command_wait_time);
+        Thread::sleep(data::EmergencyBrakes::kBrakeCommandWaitTime);
         m_brake_->checkHome();
         f_brake_->checkHome();
         m_brake_->checkAccFailure();
@@ -115,7 +115,7 @@ void Main::run()
         if (!f_brake_->checkClamped()) {
           f_brake_->sendClamp();
         }
-        Thread::sleep(em_brakes_.brake_command_wait_time);
+        Thread::sleep(data::EmergencyBrakes::kBrakeCommandWaitTime);
         m_brake_->checkHome();
         f_brake_->checkHome();
 
@@ -129,7 +129,7 @@ void Main::run()
         if (!f_brake_->checkClamped()) {
           f_brake_->sendClamp();
         }
-        Thread::sleep(em_brakes_.brake_command_wait_time);
+        Thread::sleep(data::EmergencyBrakes::kBrakeCommandWaitTime);
         m_brake_->checkHome();
         f_brake_->checkHome();
 
@@ -144,7 +144,7 @@ void Main::run()
           if (!f_brake_->checkClamped()) {
             f_brake_->sendClamp();
           }
-          Thread::sleep(em_brakes_.brake_command_wait_time);
+          Thread::sleep(data::EmergencyBrakes::kBrakeCommandWaitTime);
           m_brake_->checkHome();
           f_brake_->checkHome();
           m_brake_->checkBrakingFailure();
@@ -156,7 +156,7 @@ void Main::run()
           if (f_brake_->checkClamped()) {
             f_brake_->sendRetract();
           }
-          Thread::sleep(em_brakes_.brake_command_wait_time);
+          Thread::sleep(data::EmergencyBrakes::kBrakeCommandWaitTime);
           m_brake_->checkHome();
           f_brake_->checkHome();
           m_brake_->checkAccFailure();

--- a/src/state_machine/transitions.cpp
+++ b/src/state_machine/transitions.cpp
@@ -126,8 +126,8 @@ bool checkShutdownCommand(Logger &log, Telemetry &telemetry_data)
 
 bool checkEnteredBrakingZone(Logger &log, Navigation &nav_data)
 {
-  float remaining_distance = nav_data.run_length - nav_data.displacement;
-  float required_distance  = nav_data.braking_distance + nav_data.braking_buffer;
+  data::nav_t remaining_distance = Navigation::kRunLength - nav_data.displacement;
+  data::nav_t required_distance  = nav_data.braking_distance + Navigation::kBrakingBuffer;
   if (remaining_distance > required_distance) return false;
 
   log.INFO(Messages::kStmLoggingIdentifier, Messages::kBrakingZoneLog);

--- a/test/src/state_machine/transitions.test.cpp
+++ b/test/src/state_machine/transitions.test.cpp
@@ -761,13 +761,14 @@ TEST_F(TransitionFunctionality, handlesEnoughSpaceLeft)
   constexpr int min_displacement     = 0;
   constexpr int min_braking_distance = 0;
   constexpr int max_braking_distance
-    = static_cast<int>(nav_data.run_length - nav_data.braking_buffer);
+    = static_cast<int>(Navigation::kRunLength - Navigation::kBrakingBuffer);
 
   std::vector<nav_t> displacements, braking_distances;
   for (int i = 0; i < TEST_SIZE; i++) {
     nav_data.braking_distance
       = static_cast<nav_t>(randomInRange(min_braking_distance, max_braking_distance));
-    max_displacement = nav_data.run_length - nav_data.braking_buffer - nav_data.braking_distance;
+    max_displacement
+      = Navigation::kRunLength - Navigation::kBrakingBuffer - nav_data.braking_distance;
     nav_data.displacement = static_cast<nav_t>(randomInRange(min_displacement, max_displacement));
     nav_data.velocity     = static_cast<nav_t>(rand());
     nav_data.acceleration = nav_data.velocity;
@@ -789,14 +790,15 @@ TEST_F(TransitionFunctionality, handlesNotEnoughSpaceLeft)
   Navigation nav_data;
   int min_displacement;
 
-  constexpr int max_displacement     = nav_data.run_length * 2;
+  constexpr int max_displacement     = Navigation::kRunLength * 2;
   constexpr int min_braking_distance = 0;
-  constexpr int max_braking_distance = nav_data.run_length;
+  constexpr int max_braking_distance = Navigation::kRunLength;
 
   for (int i = 0; i < TEST_SIZE; i++) {
     nav_data.braking_distance
       = static_cast<nav_t>(randomInRange(min_braking_distance, max_braking_distance));
-    min_displacement = nav_data.run_length - nav_data.braking_buffer - nav_data.braking_distance;
+    min_displacement
+      = Navigation::kRunLength - Navigation::kBrakingBuffer - nav_data.braking_distance;
     nav_data.displacement = static_cast<nav_t>(randomInRange(min_displacement, max_displacement));
     nav_data.velocity     = static_cast<nav_t>(rand());
     nav_data.acceleration = static_cast<nav_t>(rand());
@@ -821,14 +823,14 @@ TEST_F(TransitionFunctionality, handlesDisplacementOnEdgeOfBrakingZone)
   nav_t critical_displacement;
 
   constexpr int min_braking_distance = 0;
-  constexpr int max_braking_distance = nav_data.run_length;
+  constexpr int max_braking_distance = Navigation::kRunLength;
   constexpr nav_t step_size          = 1.0 / static_cast<nav_t>(TEST_SIZE);
 
   for (int i = 0; i < TEST_SIZE; i++) {
     nav_data.braking_distance
       = static_cast<nav_t>(randomInRange(min_braking_distance, max_braking_distance));
     critical_displacement
-      = nav_data.run_length - nav_data.braking_buffer - nav_data.braking_distance;
+      = Navigation::kRunLength - Navigation::kBrakingBuffer - nav_data.braking_distance;
 
     for (int j = 0; j < TEST_SIZE; j++) {
       nav_data.displacement = critical_displacement - 0.5 + step_size * static_cast<nav_t>(j);
@@ -858,13 +860,13 @@ TEST_F(TransitionFunctionality, handlesBrakingDistanceOnEdgeOfBrakingZone)
   nav_t critical_braking_distance;
 
   constexpr int min_displacement = 0;
-  constexpr int max_displacement = nav_data.run_length - nav_data.braking_buffer - 1;
+  constexpr int max_displacement = Navigation::kRunLength - Navigation::kBrakingBuffer - 1;
   constexpr nav_t step_size      = 1.0 / static_cast<nav_t>(TEST_SIZE);
 
   for (int i = 0; i < TEST_SIZE; i++) {
     nav_data.displacement = static_cast<nav_t>(randomInRange(min_displacement, max_displacement));
     critical_braking_distance
-      = nav_data.run_length - nav_data.braking_buffer - nav_data.displacement;
+      = Navigation::kRunLength - Navigation::kBrakingBuffer - nav_data.displacement;
 
     for (int j = 0; j < TEST_SIZE; j++) {
       nav_data.braking_distance


### PR DESCRIPTION
Some constant values in `data` were not stylised as such. This has now been fixed.