### PR TITLE
Fix Navigation bug with dimensions of Matrices

### DIFF
--- a/hyped.code-workspace
+++ b/hyped.code-workspace
@@ -35,8 +35,5 @@
     "editor.detectIndentation": false,
     "C_Cpp.default.cppStandard": "c++11",
     "C_Cpp.default.cStandard": "c11",
-    "files.associations": {
-      "stdexcept": "cpp"
-    },
   }
 }

--- a/hyped.code-workspace
+++ b/hyped.code-workspace
@@ -35,5 +35,8 @@
     "editor.detectIndentation": false,
     "C_Cpp.default.cppStandard": "c++11",
     "C_Cpp.default.cStandard": "c11",
+    "files.associations": {
+      "stdexcept": "cpp"
+    },
   }
 }

--- a/src/utils/math/kalman_multivariate.cpp
+++ b/src/utils/math/kalman_multivariate.cpp
@@ -39,24 +39,21 @@ namespace hyped {
 
             void KalmanMultivariate::setDynamicsModel(MatrixXf& A, MatrixXf& Q)
             {
-                if (A.cols() != n_ || A.rows() != n_ || Q.cols() != n_ ||  Q.rows() != n_ ) {
+                if (A.cols() != n_ || A.rows() != n_ || Q.cols() != n_ ||  Q.rows() != n_) {
                   throw  std::invalid_argument("Wrong dimension of the Matrices");
-              }
-              else{
+              } else {
                 A_ = A;
                 Q_ = Q;
               }
-               
             }
 
             void KalmanMultivariate::setDynamicsModel(MatrixXf& A, MatrixXf& B, MatrixXf& Q)
             {
-                if (A.cols() != n_ || A.rows() != n_ || Q.cols()!= n_ ||  Q.rows()!= n_ || 
-                    B.rows() != n_ || B.cols()!= k_) {
+                if (A.cols() != n_ || A.rows() != n_ || Q.cols()!= n_ ||  Q.rows()!= n_ ||
+                    B.rows() != n_ || B.cols()!= k_)
+                    {
                         throw  std::invalid_argument("Wrong dimension of the Matrices");
-                    }
-                else
-                {
+                    } else {
                 A_ = A;
                 B_ = B;
                 Q_ = Q;
@@ -67,15 +64,11 @@ namespace hyped {
             {
                 if (R.cols() != m_ || R.rows() != m_ || H.rows() != m_ || H.cols() != n_) {
                     throw  std::invalid_argument("Wrong dimension of the Matrices");
-              }
-              else
-              {
+                } else {
                 H_ = H;
                 R_ = R;
               }
-               
             }
-
             void KalmanMultivariate::setModels(MatrixXf& A, MatrixXf& Q, MatrixXf& H,
                                        MatrixXf& R)
             {
@@ -92,34 +85,27 @@ namespace hyped {
 
             void KalmanMultivariate::updateA(MatrixXf& A)
             {
-
                 if (A.cols() != n_ || A.rows() != n_) {
                   throw  std::invalid_argument("Wrong dimension of the Matrices");
-                }
-                else
-                {
+                } else {
                 A_ = A;
                 }
-
             }
 
             void KalmanMultivariate::updateR(MatrixXf& R)
             {
                 if (R.cols() != m_ || R.rows() != m_) {
                   throw  std::invalid_argument("Wrong dimension of the Matrices");
-                }
-                else{
+                } else {
                  R_ = R;
                 }
             }
 
             void KalmanMultivariate::setInitial(VectorXf& x0, MatrixXf& P0)
             {
-               if(x0.rows() != n_ || P0.rows() != n_ || P0.cols() != n_) {
+               if (x0.rows() != n_ || P0.rows() != n_ || P0.cols() != n_) {
                 throw std::invalid_argument("Dimension of Matrices not correct");
-                }
-                else
-                {
+                } else {
                 x_ = x0;
                 P_ = P0;
                 I_ = MatrixXf::Identity(n_, n_);

--- a/src/utils/math/kalman_multivariate.cpp
+++ b/src/utils/math/kalman_multivariate.cpp
@@ -41,10 +41,10 @@ namespace hyped {
             {
                 if (A.cols() != n_ || A.rows() != n_ || Q.cols() != n_ ||  Q.rows() != n_) {
                   throw  std::invalid_argument("Wrong dimension of the Matrices");
-              } else {
-                A_ = A;
-                Q_ = Q;
-              }
+                } else {
+                  A_ = A;
+                  Q_ = Q;
+               }
             }
 
             void KalmanMultivariate::setDynamicsModel(MatrixXf& A, MatrixXf& B, MatrixXf& Q)
@@ -52,22 +52,22 @@ namespace hyped {
                 if (A.cols() != n_ || A.rows() != n_ || Q.cols()!= n_ ||  Q.rows()!= n_ ||
                     B.rows() != n_ || B.cols()!= k_)
                     {
-                        throw  std::invalid_argument("Wrong dimension of the Matrices");
+                      throw  std::invalid_argument("Wrong dimension of the Matrices");
                     } else {
-                A_ = A;
-                B_ = B;
-                Q_ = Q;
-                }
+                      A_ = A;
+                      B_ = B;
+                      Q_ = Q;
+                    }
             }
 
             void KalmanMultivariate::setMeasurementModel(MatrixXf& H, MatrixXf& R)
             {
                 if (R.cols() != m_ || R.rows() != m_ || H.rows() != m_ || H.cols() != n_) {
-                    throw  std::invalid_argument("Wrong dimension of the Matrices");
+                  throw  std::invalid_argument("Wrong dimension of the Matrices");
                 } else {
-                H_ = H;
-                R_ = R;
-              }
+                  H_ = H;
+                  R_ = R;
+                }
             }
             void KalmanMultivariate::setModels(MatrixXf& A, MatrixXf& Q, MatrixXf& H,
                                        MatrixXf& R)
@@ -88,7 +88,7 @@ namespace hyped {
                 if (A.cols() != n_ || A.rows() != n_) {
                   throw  std::invalid_argument("Wrong dimension of the Matrices");
                 } else {
-                A_ = A;
+                  A_ = A;
                 }
             }
 
@@ -97,7 +97,7 @@ namespace hyped {
                 if (R.cols() != m_ || R.rows() != m_) {
                   throw  std::invalid_argument("Wrong dimension of the Matrices");
                 } else {
-                 R_ = R;
+                  R_ = R;
                 }
             }
 
@@ -106,10 +106,10 @@ namespace hyped {
                if (x0.rows() != n_ || P0.rows() != n_ || P0.cols() != n_) {
                 throw std::invalid_argument("Dimension of Matrices not correct");
                 } else {
-                x_ = x0;
-                P_ = P0;
-                I_ = MatrixXf::Identity(n_, n_);
-              }
+                  x_ = x0;
+                  P_ = P0;
+                  I_ = MatrixXf::Identity(n_, n_);
+               }
             }
 
             void KalmanMultivariate::predict()

--- a/src/utils/math/kalman_multivariate.cpp
+++ b/src/utils/math/kalman_multivariate.cpp
@@ -65,7 +65,7 @@ namespace hyped {
 
             void KalmanMultivariate::setMeasurementModel(MatrixXf& H, MatrixXf& R)
             {
-                if (R.cols() != m_ || R.rows() != m_ || H.rows() != m_ || H.cols()! = n_) {
+                if (R.cols() != m_ || R.rows() != m_ || H.rows() != m_ || H.cols() != n_) {
                     throw  std::invalid_argument("Wrong dimension of the Matrices");
               }
               else

--- a/src/utils/math/kalman_multivariate.cpp
+++ b/src/utils/math/kalman_multivariate.cpp
@@ -39,21 +39,44 @@ namespace hyped {
 
             void KalmanMultivariate::setDynamicsModel(MatrixXf& A, MatrixXf& Q)
             {
+                if (A.cols()!= n_ || A.rows()!= n_ || Q.cols()!=n_ ||  Q.rows()!=n_ )
+                {
+                  throw  std::invalid_argument("Wrong dimension of the Matrices");
+              }
+              else{
                 A_ = A;
                 Q_ = Q;
+              }
+               
             }
 
             void KalmanMultivariate::setDynamicsModel(MatrixXf& A, MatrixXf& B, MatrixXf& Q)
             {
+                if (A.cols()!= n_ || A.rows()!= n_ || Q.cols()!=n_ ||  Q.rows()!=n_ || 
+                    B.rows()!=n_ || B.cols()!=k_)
+                    {
+                        throw  std::invalid_argument("Wrong dimension of the Matrices");
+                    }
+                else
+                {
                 A_ = A;
                 B_ = B;
                 Q_ = Q;
+                }
             }
 
             void KalmanMultivariate::setMeasurementModel(MatrixXf& H, MatrixXf& R)
             {
+                if (R.cols()!= m_ || R.rows()!=m_||H.rows()!=m_ || H.cols()!=n_)
+                {
+                    throw  std::invalid_argument("Wrong dimension of the Matrices");
+              }
+              else
+              {
                 H_ = H;
                 R_ = R;
+              }
+               
             }
 
             void KalmanMultivariate::setModels(MatrixXf& A, MatrixXf& Q, MatrixXf& H,
@@ -72,19 +95,41 @@ namespace hyped {
 
             void KalmanMultivariate::updateA(MatrixXf& A)
             {
+
+                if (A.cols()!= n_ || A.rows()!=n_)
+                {
+                  throw  std::invalid_argument("Wrong dimension of the Matrices");
+                }
+                else
+                {
                 A_ = A;
+                }
+
             }
 
             void KalmanMultivariate::updateR(MatrixXf& R)
             {
-                R_ = R;
+                if (R.cols()!= m_ || R.rows()!=m_)
+                {
+                  throw  std::invalid_argument("Wrong dimension of the Matrices");
+                }
+                else{
+                 R_ = R;
+                }
             }
 
             void KalmanMultivariate::setInitial(VectorXf& x0, MatrixXf& P0)
             {
+               if(x0.rows()!=n_ || P0.rows()!=n_ || P0.cols()!=n_)
+               {
+                throw std::invalid_argument("Dimension of Matrices not correct");
+                }
+                else
+                {
                 x_ = x0;
                 P_ = P0;
                 I_ = MatrixXf::Identity(n_, n_);
+              }
             }
 
             void KalmanMultivariate::predict()

--- a/src/utils/math/kalman_multivariate.cpp
+++ b/src/utils/math/kalman_multivariate.cpp
@@ -39,8 +39,7 @@ namespace hyped {
 
             void KalmanMultivariate::setDynamicsModel(MatrixXf& A, MatrixXf& Q)
             {
-                if (A.cols()!= n_ || A.rows()!= n_ || Q.cols()!=n_ ||  Q.rows()!=n_ )
-                {
+                if (A.cols()!= n_ || A.rows()!= n_ || Q.cols()!=n_ ||  Q.rows()!=n_ ) {
                   throw  std::invalid_argument("Wrong dimension of the Matrices");
               }
               else{
@@ -53,8 +52,7 @@ namespace hyped {
             void KalmanMultivariate::setDynamicsModel(MatrixXf& A, MatrixXf& B, MatrixXf& Q)
             {
                 if (A.cols()!= n_ || A.rows()!= n_ || Q.cols()!=n_ ||  Q.rows()!=n_ || 
-                    B.rows()!=n_ || B.cols()!=k_)
-                    {
+                    B.rows()!=n_ || B.cols()!=k_) {
                         throw  std::invalid_argument("Wrong dimension of the Matrices");
                     }
                 else
@@ -67,8 +65,7 @@ namespace hyped {
 
             void KalmanMultivariate::setMeasurementModel(MatrixXf& H, MatrixXf& R)
             {
-                if (R.cols()!= m_ || R.rows()!=m_||H.rows()!=m_ || H.cols()!=n_)
-                {
+                if (R.cols()!= m_ || R.rows()!=m_||H.rows()!=m_ || H.cols()!=n_) {
                     throw  std::invalid_argument("Wrong dimension of the Matrices");
               }
               else
@@ -96,8 +93,7 @@ namespace hyped {
             void KalmanMultivariate::updateA(MatrixXf& A)
             {
 
-                if (A.cols()!= n_ || A.rows()!=n_)
-                {
+                if (A.cols()!= n_ || A.rows()!=n_) {
                   throw  std::invalid_argument("Wrong dimension of the Matrices");
                 }
                 else
@@ -109,8 +105,7 @@ namespace hyped {
 
             void KalmanMultivariate::updateR(MatrixXf& R)
             {
-                if (R.cols()!= m_ || R.rows()!=m_)
-                {
+                if (R.cols()!= m_ || R.rows()!=m_) {
                   throw  std::invalid_argument("Wrong dimension of the Matrices");
                 }
                 else{
@@ -120,8 +115,7 @@ namespace hyped {
 
             void KalmanMultivariate::setInitial(VectorXf& x0, MatrixXf& P0)
             {
-               if(x0.rows()!=n_ || P0.rows()!=n_ || P0.cols()!=n_)
-               {
+               if(x0.rows()!=n_ || P0.rows()!=n_ || P0.cols()!=n_) {
                 throw std::invalid_argument("Dimension of Matrices not correct");
                 }
                 else

--- a/src/utils/math/kalman_multivariate.cpp
+++ b/src/utils/math/kalman_multivariate.cpp
@@ -39,7 +39,7 @@ namespace hyped {
 
             void KalmanMultivariate::setDynamicsModel(MatrixXf& A, MatrixXf& Q)
             {
-                if (A.cols()!= n_ || A.rows()!= n_ || Q.cols()!=n_ ||  Q.rows()!=n_ ) {
+                if (A.cols() != n_ || A.rows() != n_ || Q.cols() != n_ ||  Q.rows() != n_ ) {
                   throw  std::invalid_argument("Wrong dimension of the Matrices");
               }
               else{
@@ -51,8 +51,8 @@ namespace hyped {
 
             void KalmanMultivariate::setDynamicsModel(MatrixXf& A, MatrixXf& B, MatrixXf& Q)
             {
-                if (A.cols()!= n_ || A.rows()!= n_ || Q.cols()!=n_ ||  Q.rows()!=n_ || 
-                    B.rows()!=n_ || B.cols()!=k_) {
+                if (A.cols() != n_ || A.rows() != n_ || Q.cols()!= n_ ||  Q.rows()!= n_ || 
+                    B.rows() != n_ || B.cols()!= k_) {
                         throw  std::invalid_argument("Wrong dimension of the Matrices");
                     }
                 else
@@ -65,7 +65,7 @@ namespace hyped {
 
             void KalmanMultivariate::setMeasurementModel(MatrixXf& H, MatrixXf& R)
             {
-                if (R.cols()!= m_ || R.rows()!=m_||H.rows()!=m_ || H.cols()!=n_) {
+                if (R.cols() != m_ || R.rows() != m_ || H.rows() != m_ || H.cols()! = n_) {
                     throw  std::invalid_argument("Wrong dimension of the Matrices");
               }
               else
@@ -93,7 +93,7 @@ namespace hyped {
             void KalmanMultivariate::updateA(MatrixXf& A)
             {
 
-                if (A.cols()!= n_ || A.rows()!=n_) {
+                if (A.cols() != n_ || A.rows() != n_) {
                   throw  std::invalid_argument("Wrong dimension of the Matrices");
                 }
                 else
@@ -105,7 +105,7 @@ namespace hyped {
 
             void KalmanMultivariate::updateR(MatrixXf& R)
             {
-                if (R.cols()!= m_ || R.rows()!=m_) {
+                if (R.cols() != m_ || R.rows() != m_) {
                   throw  std::invalid_argument("Wrong dimension of the Matrices");
                 }
                 else{
@@ -115,7 +115,7 @@ namespace hyped {
 
             void KalmanMultivariate::setInitial(VectorXf& x0, MatrixXf& P0)
             {
-               if(x0.rows()!=n_ || P0.rows()!=n_ || P0.cols()!=n_) {
+               if(x0.rows() != n_ || P0.rows() != n_ || P0.cols() != n_) {
                 throw std::invalid_argument("Dimension of Matrices not correct");
                 }
                 else


### PR DESCRIPTION
## Description
The code for KalmanMultivariate now checks if the dimension of the given matrices correspond to the expected dimensions, if there is a matrix (or vector) with wrong dimensions is passed to the programme it will throw an exception. It is up to Navigation Team to decide what to do with that exception. However, this situation is not expected unless someone breaks the code by passing directly a wrong matrix to the programme. Therefore, it should not affect the current version in develop.

## Changes
- KalmanMultivariate.cpp: Now in all the methods that reassign matrices or vectors there is a checker that will look if the dimensions of the given objects are correct.
## Additional Information
Fixes #68