### PR TITLE
[WIP] QA New Kalman Multivariate New Tests

### DIFF
--- a/hyped.code-workspace
+++ b/hyped.code-workspace
@@ -35,8 +35,5 @@
     "editor.detectIndentation": false,
     "C_Cpp.default.cppStandard": "c++11",
     "C_Cpp.default.cStandard": "c11",
-    "files.associations": {
-      "stdexcept": "cpp"
-    },
   }
 }

--- a/hyped.code-workspace
+++ b/hyped.code-workspace
@@ -35,5 +35,8 @@
     "editor.detectIndentation": false,
     "C_Cpp.default.cppStandard": "c++11",
     "C_Cpp.default.cStandard": "c11",
+    "files.associations": {
+      "stdexcept": "cpp"
+    },
   }
 }

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -152,7 +152,7 @@ struct KalmanMathematics : public::testing::Test {
 
   void TearDown() {}
 };
-TEST_F(KalmanMathematics,handlesSeveralFiltersWithControl)
+TEST_F(KalmanMathematics, handlesSeveralFiltersWithControl)
 { 
     MatrixXf A = A_Data[0];
     MatrixXf B = B_Data[0];
@@ -165,8 +165,8 @@ TEST_F(KalmanMathematics,handlesSeveralFiltersWithControl)
     kalmanMathWithControl.setInitial(x1_Data[0], P_Data[0]);
     VectorXf x = kalmanMathWithControl.getStateEstimate();
     MatrixXf p = kalmanMathWithControl.getStateCovariance();
-  for(int i =0; i<50; i++){
-     kalmanMathWithControl.filter(u, z);
+  for (int i = 0; i < 50; i++) {
+    kalmanMathWithControl.filter(u, z);
     // Mimicks filter(VectorXf& u, VectorXf& z)
     x = A * x + B * u;
     p = (A * p * A.transpose()) + Q;
@@ -180,7 +180,7 @@ TEST_F(KalmanMathematics,handlesSeveralFiltersWithControl)
       << expected_covariance_err;
   }
 }
-TEST_F(KalmanMathematics,handlesSeveralFiltersWithoutControl)
+TEST_F(KalmanMathematics, handlesSeveralFiltersWithoutControl)
 { 
     MatrixXf A = A_Data[0];
     MatrixXf B = B_Data[0];
@@ -193,11 +193,8 @@ TEST_F(KalmanMathematics,handlesSeveralFiltersWithoutControl)
     kalmanMathWithoutControl.setInitial(x1_Data[0], P_Data[0]);
     VectorXf x = kalmanMathWithoutControl.getStateEstimate();
     MatrixXf p = kalmanMathWithoutControl.getStateCovariance();
-  for(int i =0; i<50; i++){
-    std::cout<<i<<"\n";
+  for (int i =0; i < 50; i++) {
     kalmanMathWithoutControl.filter(u, z);
-    std::cout<<i<<"\n";
-     
     // Mimicks filter(VectorXf& u, VectorXf& z)
     x = A * x + B * u;
     p = (A * p * A.transpose()) + Q;

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -273,7 +273,7 @@ TEST_F(KalmanMathematics, handlesSeveralFiltersWithoutControl)
     kalmanMathWithoutControl.setInitial(x1_Data[0], P_Data[0]);
     VectorXf x = kalmanMathWithoutControl.getStateEstimate();
     MatrixXf p = kalmanMathWithoutControl.getStateCovariance();
-  for (int i =0; i < 50; i++) {
+  for (int i =0; i < NUM_TESTDATA; i++) {
     kalmanMathWithoutControl.filter(z);
     // Mimicks filter(VectorXf& u, VectorXf& z)
     x = A * x;
@@ -373,6 +373,7 @@ struct KalmanIdentity : public ::testing::Test {
   unsigned int k = 1;
 
   KalmanMultivariate kalman = KalmanMultivariate(n, m, k);
+  static constexpr int NUM_TESTDATA = 50;
   VectorXf x0 = VectorXf::Random(n);
   VectorXf x1 = VectorXf::Random(n);
   VectorXf z = VectorXf::Zero(m);
@@ -413,7 +414,7 @@ struct KalmanIdentity : public ::testing::Test {
  */
 TEST_F(KalmanIdentity, handlesIdentity)
 {
-  for (int i = 0; i < 50; i++) {
+  for (int i = 0; i < NUM_TESTDATA; i++) {
     kalman.filter(u, z);
     ASSERT_EQ(kalman.getStateEstimate(), x0);
     ASSERT_EQ(kalman.getStateCovariance(), P);

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -103,6 +103,11 @@ TEST_F(KalmanFunctionality, handlesArbitraryStateCovariance)
 {
   ASSERT_EQ(kalman.getStateCovariance(), P) << arb_covariance_err;
 }
+
+/**
+ * Test fixture used for determining whether Kalman handles an update on the State transition matrix
+ * It will be updated twice, first to the Zero Matrix and then to to Identity Matrix
+ */
 TEST_F(KalmanFunctionality, handlesUpdateInA)
 {
   KalmanMultivariate kalman_two = KalmanMultivariate(n, m, 0);
@@ -136,6 +141,11 @@ TEST_F(KalmanFunctionality, handlesUpdateInA)
   ASSERT_EQ(kalman_two.getStateEstimate(), x1);
   ASSERT_NE(kalman_two.getStateEstimate(), kalman.getStateEstimate());
 }
+
+/**
+ * Test fixture used for determining whether Kalman handles an update on the Noise covariance matrix
+ * It will be updated once to a random matrix and it starts being the identity.
+ */
 TEST_F(KalmanFunctionality, handlesUpdateInR)
 {
   KalmanMultivariate kalman_two = KalmanMultivariate(n, m, 0);

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -414,10 +414,10 @@ TEST_F(KalmanIdentity, handlesIdentity)
 {
   for (int i = 0; i < NUM_TESTDATA; i++) {
     kalman.filter(u, z);
-    ASSERT_EQ(kalman.getStateEstimate(), x0);
-      << identity_error
-    ASSERT_EQ(kalman.getStateCovariance(), P);
-      << identity_error
+    ASSERT_EQ(kalman.getStateEstimate(), x0)
+      << identity_error;
+    ASSERT_EQ(kalman.getStateCovariance(), P)
+      << identity_error;
   }
 }
 

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -415,9 +415,9 @@ TEST_F(KalmanIdentity, handlesIdentity)
   for (int i = 0; i < NUM_TESTDATA; i++) {
     kalman.filter(u, z);
     ASSERT_EQ(kalman.getStateEstimate(), x0)
-      << identity_error;
+      << identity_err;
     ASSERT_EQ(kalman.getStateCovariance(), P)
-      << identity_error;
+      << identity_err;
   }
 }
 

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -103,7 +103,39 @@ TEST_F(KalmanFunctionality, handlesArbitraryStateCovariance)
 {
   ASSERT_EQ(kalman.getStateCovariance(), P) << arb_covariance_err;
 }
-
+TEST_F(KalmanFunctionality, handlesUpdateInA)
+{
+  KalmanMultivariate kalman_two = KalmanMultivariate(n, m, 0);
+  VectorXf x1 = VectorXf::Random(n);
+  while (x1 == VectorXf::Zero(n)) {
+    x1 = VectorXf::Random(n, n);
+  }
+  A = MatrixXf::Random(n, n);
+  while (A == MatrixXf::Zero(n, n) || A == MatrixXf::Identity(n, n)) {
+    A = MatrixXf::Random(n, n);
+  }
+  B = MatrixXf::Zero(n, k);
+  Q = MatrixXf::Zero(n, n);
+  H = MatrixXf::Zero(m, n);
+  R = MatrixXf::Identity(m, m);
+  kalman.setModels(A, Q, H, R);
+  kalman_two.setModels(A, Q, H, R);
+  A = MatrixXf::Zero(n, n);
+  kalman_two.updateA(A);
+  kalman.setInitial(x1, P);
+  kalman_two.setInitial(x1, P);
+  z = VectorXf::Zero(m);
+  kalman_two.filter(z);
+  kalman.filter(z);
+  ASSERT_EQ(kalman_two.getStateEstimate(), VectorXf::Zero(n));
+  ASSERT_NE(kalman_two.getStateEstimate(), kalman.getStateEstimate());
+  A = MatrixXf::Identity(n, n);
+  kalman_two.updateA(A);
+  kalman_two.setInitial(x1, P);
+  kalman_two.filter(z);
+  ASSERT_EQ(kalman_two.getStateEstimate(), x1);
+  ASSERT_NE(kalman_two.getStateEstimate(), kalman.getStateEstimate());
+}
 // -------------------------------------------------------------------------------------------------
 // Mathematical Properties
 // -------------------------------------------------------------------------------------------------

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -56,6 +56,7 @@ struct KalmanFunctionality : public ::testing::Test {
   std::string arb_state_estimate_err = "Should handle any arbitrary vector as state estimate";
   std::string zero_covariance_err = "Should handle zero state covariance";
   std::string arb_covariance_err = "Should handle any arbitrary state covariance";
+  std::string update_err = "Should allow updating the matrix";
 
   void SetUp()
   {
@@ -132,14 +133,18 @@ TEST_F(KalmanFunctionality, handlesUpdateInA)
   z = VectorXf::Zero(m);
   kalman_two.filter(z);
   kalman.filter(z);
-  ASSERT_EQ(kalman_two.getStateEstimate(), VectorXf::Zero(n));
-  ASSERT_NE(kalman_two.getStateEstimate(), kalman.getStateEstimate());
+  ASSERT_EQ(kalman_two.getStateEstimate(), VectorXf::Zero(n))
+    <<update_err;
+  ASSERT_NE(kalman_two.getStateEstimate(), kalman.getStateEstimate())
+    <<update_err;
   A = MatrixXf::Identity(n, n);
   kalman_two.updateA(A);
   kalman_two.setInitial(x1, P);
   kalman_two.filter(z);
-  ASSERT_EQ(kalman_two.getStateEstimate(), x1);
-  ASSERT_NE(kalman_two.getStateEstimate(), kalman.getStateEstimate());
+  ASSERT_EQ(kalman_two.getStateEstimate(), x1)
+    <<update_err;
+  ASSERT_NE(kalman_two.getStateEstimate(), kalman.getStateEstimate())
+    <<update_err;
 }
 
 /**
@@ -170,7 +175,8 @@ TEST_F(KalmanFunctionality, handlesUpdateInR)
   z = VectorXf::Random(m);
   kalman_two.filter(z);
   kalman.filter(z);
-  ASSERT_NE(kalman_two.getStateEstimate(), kalman.getStateEstimate());
+  ASSERT_NE(kalman_two.getStateEstimate(), kalman.getStateEstimate())
+    <<update_err;
 }
 // -------------------------------------------------------------------------------------------------
 // Mathematical Properties

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -247,14 +247,14 @@ TEST_F(KalmanMathematics, handlesSeveralFiltersWithoutControl)
     MatrixXf R = R_Data[0];
     VectorXf z = z_Data[0];
     VectorXf u = u_Data[0];
-    kalmanMathWithoutControl.setModels(A, B, Q, H, R);
+    kalmanMathWithoutControl.setModels(A, Q, H, R);
     kalmanMathWithoutControl.setInitial(x1_Data[0], P_Data[0]);
     VectorXf x = kalmanMathWithoutControl.getStateEstimate();
     MatrixXf p = kalmanMathWithoutControl.getStateCovariance();
   for (int i =0; i < 50; i++) {
-    kalmanMathWithoutControl.filter(u, z);
+    kalmanMathWithoutControl.filter(z);
     // Mimicks filter(VectorXf& u, VectorXf& z)
-    x = A * x + B * u;
+    x = A * x;
     p = (A * p * A.transpose()) + Q;
       // Mimicks correct()
     MatrixXf K = (p * H.transpose()) * (H * p * H.transpose() + R).inverse();

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -384,3 +384,65 @@ TEST_F(KalmanIdentity, handlesIdentity)
     ASSERT_EQ(kalman.getStateCovariance(), P);
   }
 }
+
+struct KalmanExceptions : public ::testing::Test {
+ public:
+  unsigned int n = 2;
+  unsigned int m = 3;
+  unsigned int k = 1;
+  unsigned int c = 10;
+
+  KalmanMultivariate kalman = KalmanMultivariate(n, m, 0);
+  VectorXf x0 = VectorXf::Zero(c);
+  VectorXf x1 = VectorXf::Random(n);
+  VectorXf z = VectorXf::Random(n);
+  MatrixXf P0 = MatrixXf::Zero(n, n);
+  MatrixXf A = MatrixXf::Random(n, n);
+  MatrixXf B = MatrixXf::Random(n, k);
+  MatrixXf Q = MatrixXf::Random(n, n);
+  MatrixXf H = MatrixXf::Random(m, n);
+  MatrixXf R = MatrixXf::Random(m, m);
+  MatrixXf P = MatrixXf::Random(n, n);
+  std::string zero_state_estimate_err = "Should handle zero vector as state estimate";
+  std::string arb_state_estimate_err = "Should handle any arbitrary vector as state estimate";
+  std::string zero_covariance_err = "Should handle zero state covariance";
+  std::string arb_covariance_err = "Should handle any arbitrary state covariance";
+
+  void SetUp()
+  {}
+  void TearDown() {}
+};
+TEST_F(KalmanExceptions, handlesDimensionalityIssues)
+{
+  EXPECT_THROW(kalman.setInitial(x0, P0), std::invalid_argument);
+  P0=  MatrixXf::Zero(k, m);
+  VectorXf x0 = VectorXf::Zero(n);
+  EXPECT_THROW(kalman.setInitial(x0, P0), std::invalid_argument);
+  MatrixXf A = MatrixXf::Random(k, m);
+  EXPECT_THROW(kalman.updateA(A), std::invalid_argument);
+  EXPECT_THROW(kalman.setModels(A, Q, H, R), std::invalid_argument);
+  A = MatrixXf::Random(n, n);
+  Q = MatrixXf::Random(k, m);
+  EXPECT_THROW(kalman.setModels(A, Q, H, R), std::invalid_argument);
+  Q = MatrixXf::Random(n, n);
+  H = MatrixXf::Random(k, m);
+  EXPECT_THROW(kalman.setModels(A, Q, H, R), std::invalid_argument);
+  H = MatrixXf::Random(n, n);
+  R =MatrixXf::Random(k, m);
+  EXPECT_THROW(kalman.setModels(A, Q, H, R), std::invalid_argument);
+  A = MatrixXf::Random(k, m);
+  EXPECT_THROW(kalman.setModels(A, B, Q, H, R), std::invalid_argument);
+  A = MatrixXf::Random(n, n);
+  Q = MatrixXf::Random(k, m);
+  EXPECT_THROW(kalman.setModels(A, B, Q, H, R), std::invalid_argument);
+  Q = MatrixXf::Random(n, n);
+  H = MatrixXf::Random(k, m);
+  EXPECT_THROW(kalman.setModels(A, B, Q, H, R), std::invalid_argument);
+  H = MatrixXf::Random(n, n);
+  R =MatrixXf::Random(k, m);
+  EXPECT_THROW(kalman.updateR(R), std::invalid_argument);
+  EXPECT_THROW(kalman.setModels(A, B, Q, H, R), std::invalid_argument);
+  R = MatrixXf::Random(m, m);
+  B =MatrixXf::Random(k, m);
+  EXPECT_THROW(kalman.setModels(A, B, Q, H, R), std::invalid_argument);
+}

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -238,6 +238,13 @@ TEST_F(KalmanMathematics, handlesSeveralFiltersWithControl)
       << expected_covariance_err;
   }
 }
+/**
+ * Test fixture for testing whether the filter (without control) updates the X Vector and P Matrix
+ * accordingly in several filter operations.
+ * Maths has been replicated throughout since to track the values updating and final
+ * assert at the end checks that the values are as expected.
+ * Checks that both the X vector and P Matrix are updated appropriately
+ */
 TEST_F(KalmanMathematics, handlesSeveralFiltersWithoutControl)
 {
     MatrixXf A = A_Data[0];

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -388,7 +388,7 @@ struct KalmanIdentity : public ::testing::Test {
   MatrixXf R = MatrixXf::Identity(m, m);
   MatrixXf P = MatrixXf::Random(n, n);
   std::string identity_error =
-   "The filter() should not have any effect on the covariance and state given these conditions";
+    "The filter() should not have any effect on the covariance and state given these conditions";
 
   void SetUp()
   {

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -136,6 +136,32 @@ TEST_F(KalmanFunctionality, handlesUpdateInA)
   ASSERT_EQ(kalman_two.getStateEstimate(), x1);
   ASSERT_NE(kalman_two.getStateEstimate(), kalman.getStateEstimate());
 }
+TEST_F(KalmanFunctionality, handlesUpdateInR)
+{
+  KalmanMultivariate kalman_two = KalmanMultivariate(n, m, 0);
+  VectorXf x1 = VectorXf::Random(n);
+  while (x1 == VectorXf::Zero(n)) {
+    x1 = VectorXf::Random(n, n);
+  }
+  A = MatrixXf::Identity(n, n);
+  B = MatrixXf::Zero(n, k);
+  Q = MatrixXf::Zero(n, n);
+  H = MatrixXf::Random(m, n);
+  R = MatrixXf::Identity(m, m);
+  kalman.setModels(A, Q, H, R);
+  kalman_two.setModels(A, Q, H, R);
+  R = MatrixXf::Random(m, m);
+  while (R == MatrixXf::Zero(m, m) || R == MatrixXf::Identity(m, m) || R.determinant() == 0) {
+    R = MatrixXf::Random(m, m);
+  }
+  kalman_two.updateR(R);
+  kalman.setInitial(x1, P);
+  kalman_two.setInitial(x1, P);
+  z = VectorXf::Random(m);
+  kalman_two.filter(z);
+  kalman.filter(z);
+  ASSERT_NE(kalman_two.getStateEstimate(), kalman.getStateEstimate());
+}
 // -------------------------------------------------------------------------------------------------
 // Mathematical Properties
 // -------------------------------------------------------------------------------------------------

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -152,6 +152,65 @@ struct KalmanMathematics : public::testing::Test {
 
   void TearDown() {}
 };
+TEST_F(KalmanMathematics,handlesSeveralFiltersWithControl)
+{ 
+    MatrixXf A = A_Data[0];
+    MatrixXf B = B_Data[0];
+    MatrixXf Q = Q_Data[0];
+    MatrixXf H = H_Data[0];
+    MatrixXf R = R_Data[0];
+    VectorXf z = z_Data[0];
+    VectorXf u = u_Data[0];
+    kalmanMathWithControl.setModels(A, B, Q, H, R);
+    kalmanMathWithControl.setInitial(x1_Data[0], P_Data[0]);
+    VectorXf x = kalmanMathWithControl.getStateEstimate();
+    MatrixXf p = kalmanMathWithControl.getStateCovariance();
+  for(int i =0; i<50; i++){
+     kalmanMathWithControl.filter(u, z);
+    // Mimicks filter(VectorXf& u, VectorXf& z)
+    x = A * x + B * u;
+    p = (A * p * A.transpose()) + Q;
+      // Mimicks correct()
+    MatrixXf K = (p * H.transpose()) * (H * p * H.transpose() + R).inverse();
+    x = x + K * (z - H * x);
+    p = (I - K * H) * p;
+    ASSERT_EQ(kalmanMathWithControl.getStateEstimate(), x)
+      << expected_state_estimate_err;
+    ASSERT_EQ(kalmanMathWithControl.getStateCovariance(), p)
+      << expected_covariance_err;
+  }
+}
+TEST_F(KalmanMathematics,handlesSeveralFiltersWithoutControl)
+{ 
+    MatrixXf A = A_Data[0];
+    MatrixXf B = B_Data[0];
+    MatrixXf Q = Q_Data[0];
+    MatrixXf H = H_Data[0];
+    MatrixXf R = R_Data[0];
+    VectorXf z = z_Data[0];
+    VectorXf u = u_Data[0];
+    kalmanMathWithoutControl.setModels(A, B, Q, H, R);
+    kalmanMathWithoutControl.setInitial(x1_Data[0], P_Data[0]);
+    VectorXf x = kalmanMathWithoutControl.getStateEstimate();
+    MatrixXf p = kalmanMathWithoutControl.getStateCovariance();
+  for(int i =0; i<50; i++){
+    std::cout<<i<<"\n";
+    kalmanMathWithoutControl.filter(u, z);
+    std::cout<<i<<"\n";
+     
+    // Mimicks filter(VectorXf& u, VectorXf& z)
+    x = A * x + B * u;
+    p = (A * p * A.transpose()) + Q;
+      // Mimicks correct()
+    MatrixXf K = (p * H.transpose()) * (H * p * H.transpose() + R).inverse();
+    x = x + K * (z - H * x);
+    p = (I - K * H) * p;
+    ASSERT_EQ(kalmanMathWithoutControl.getStateEstimate(), x)
+      << expected_state_estimate_err;
+    ASSERT_EQ(kalmanMathWithoutControl.getStateCovariance(), p)
+      << expected_covariance_err;
+  }
+}
 
 /**
  * Test fixture for testing whether the filter (without control) updates the X Vector and P Matrix

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -240,8 +240,7 @@ TEST_F(KalmanMathematics, handlesSeveralFiltersWithControl)
 }
 /**
  * Test fixture for testing whether the filter (without control) updates the X Vector and P Matrix
- * accordingly in several filter operations.
- * Maths has been replicated throughout since to track the values updating and final
+ * accordingly. Maths has been replicated throughout since to track the values updating and final
  * assert at the end checks that the values are as expected.
  * Checks that both the X vector and P Matrix are updated appropriately
  */

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -387,7 +387,7 @@ struct KalmanIdentity : public ::testing::Test {
   MatrixXf H = MatrixXf::Zero(m, n);
   MatrixXf R = MatrixXf::Identity(m, m);
   MatrixXf P = MatrixXf::Random(n, n);
-  std::string identity_error =
+  std::string identity_err =
     "The filter() should not have any effect on the covariance and state given these conditions";
 
   void SetUp()
@@ -415,7 +415,9 @@ TEST_F(KalmanIdentity, handlesIdentity)
   for (int i = 0; i < NUM_TESTDATA; i++) {
     kalman.filter(u, z);
     ASSERT_EQ(kalman.getStateEstimate(), x0);
+      << identity_error
     ASSERT_EQ(kalman.getStateCovariance(), P);
+      << identity_error
   }
 }
 
@@ -440,10 +442,6 @@ struct KalmanExceptions : public ::testing::Test {
   MatrixXf H = MatrixXf::Random(m, n);
   MatrixXf R = MatrixXf::Random(m, m);
   MatrixXf P = MatrixXf::Random(n, n);
-  std::string zero_state_estimate_err = "Should handle zero vector as state estimate";
-  std::string arb_state_estimate_err = "Should handle any arbitrary vector as state estimate";
-  std::string zero_covariance_err = "Should handle zero state covariance";
-  std::string arb_covariance_err = "Should handle any arbitrary state covariance";
 
   void SetUp()
   {}

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -153,7 +153,7 @@ struct KalmanMathematics : public::testing::Test {
   void TearDown() {}
 };
 TEST_F(KalmanMathematics, handlesSeveralFiltersWithControl)
-{ 
+{
     MatrixXf A = A_Data[0];
     MatrixXf B = B_Data[0];
     MatrixXf Q = Q_Data[0];
@@ -181,7 +181,7 @@ TEST_F(KalmanMathematics, handlesSeveralFiltersWithControl)
   }
 }
 TEST_F(KalmanMathematics, handlesSeveralFiltersWithoutControl)
-{ 
+{
     MatrixXf A = A_Data[0];
     MatrixXf B = B_Data[0];
     MatrixXf Q = Q_Data[0];
@@ -280,5 +280,49 @@ TEST_F(KalmanMathematics, handlesFilterWithControl)
       << expected_state_estimate_err;
     ASSERT_EQ(kalmanMathWithControl.getStateCovariance(), p)
       << expected_covariance_err;
+  }
+}
+struct KalmanIdentity : public ::testing::Test {
+ protected:
+  unsigned int n = 2;
+  unsigned int m = 3;
+  unsigned int k = 1;
+
+  KalmanMultivariate kalman = KalmanMultivariate(n, m, k);
+  VectorXf x0 = VectorXf::Random(n);
+  VectorXf x1 = VectorXf::Random(n);
+  VectorXf z = VectorXf::Zero(m);
+  VectorXf u = VectorXf::Random(k);
+
+
+  MatrixXf P0 = MatrixXf::Random(n, n);
+  MatrixXf A = MatrixXf::Identity(n, n);
+  MatrixXf B = MatrixXf::Zero(n, k);
+  MatrixXf Q = MatrixXf::Zero(n, n);
+  MatrixXf H = MatrixXf::Zero(m, n);
+  MatrixXf R = MatrixXf::Identity(m, m);
+  MatrixXf P = MatrixXf::Random(n, n);
+  std::string zero_state_estimate_err = "Should handle zero vector as state estimate";
+  std::string arb_state_estimate_err = "Should handle any arbitrary vector as state estimate";
+  std::string zero_covariance_err = "Should handle zero state covariance";
+  std::string arb_covariance_err = "Should handle any arbitrary state covariance";
+
+  void SetUp()
+  {
+    // Assigns the matrices and vectors to the properties within the kalman object.
+    if (P.determinant() == 0) {
+       P = MatrixXf::Random(n, n);
+    }
+    kalman.setModels(A, B, Q, H, R);
+    kalman.setInitial(x0, P);
+  }
+  void TearDown() {}
+};
+TEST_F(KalmanIdentity, handlesIdentity)
+{
+  for (int i = 0; i < 50; i++) {
+    kalman.filter(u, z);
+    ASSERT_EQ(kalman.getStateEstimate(), x0);
+    ASSERT_EQ(kalman.getStateCovariance(), P);
   }
 }

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -387,10 +387,8 @@ struct KalmanIdentity : public ::testing::Test {
   MatrixXf H = MatrixXf::Zero(m, n);
   MatrixXf R = MatrixXf::Identity(m, m);
   MatrixXf P = MatrixXf::Random(n, n);
-  std::string zero_state_estimate_err = "Should handle zero vector as state estimate";
-  std::string arb_state_estimate_err = "Should handle any arbitrary vector as state estimate";
-  std::string zero_covariance_err = "Should handle zero state covariance";
-  std::string arb_covariance_err = "Should handle any arbitrary state covariance";
+  std::string identity_error =
+   "The filter() should not have any effect on the covariance and state given these conditions";
 
   void SetUp()
   {

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -220,6 +220,12 @@ struct KalmanMathematics : public::testing::Test {
 
   void TearDown() {}
 };
+/**
+ * Test fixture for testing whether the filter (with control) updates the X Vector and P Matrix
+ * accordingly. Maths has been replicated throughout since to track the values updating and final
+ * assert at the end checks that the values are as expected.
+ * Checks that both the X vector and P Matrix are updated appropriately
+ */
 TEST_F(KalmanMathematics, handlesSeveralFiltersWithControl)
 {
     MatrixXf A = A_Data[0];
@@ -356,6 +362,10 @@ TEST_F(KalmanMathematics, handlesFilterWithControl)
       << expected_covariance_err;
   }
 }
+/**
+ * Struct used for testing the properties of the kalman filter under identity operations, those that
+ * do not modify neither the state vector nor the vocariance matrix on each filter().
+ */
 struct KalmanIdentity : public ::testing::Test {
  protected:
   unsigned int n = 2;
@@ -392,6 +402,15 @@ struct KalmanIdentity : public ::testing::Test {
   }
   void TearDown() {}
 };
+
+/**
+ * Test fixture for testing whether the filter updates the X Vector and P Matrix
+ * accordingly, in this case the matrices have been created in a way that the state
+ * vector and the covariance should be mantained constant through all the filter() runs.
+ * Maths has been replicated throughout since to track the values updating and final
+ * assert at the end checks that the values are as expected.
+ * Checks that both the X vector and P Matrix are updated appropriately
+ */
 TEST_F(KalmanIdentity, handlesIdentity)
 {
   for (int i = 0; i < 50; i++) {
@@ -401,6 +420,9 @@ TEST_F(KalmanIdentity, handlesIdentity)
   }
 }
 
+/**
+ * Struct used for testing the excpetions thrown by the class KalmanMultivariate
+ */
 struct KalmanExceptions : public ::testing::Test {
  public:
   unsigned int n = 2;
@@ -428,6 +450,12 @@ struct KalmanExceptions : public ::testing::Test {
   {}
   void TearDown() {}
 };
+
+/**
+ * Test fixture for testing whether Kalman can andle the case of matrices having wrong dimensions,
+ * This test will change the dimensions of the different matrices and it will chek that the
+ * programme throws and appropriate exception.
+ */
 TEST_F(KalmanExceptions, handlesDimensionalityIssues)
 {
   EXPECT_THROW(kalman.setInitial(x0, P0), std::invalid_argument);

--- a/test/src/utils/kalman_multivariate.test.cpp
+++ b/test/src/utils/kalman_multivariate.test.cpp
@@ -442,6 +442,8 @@ struct KalmanExceptions : public ::testing::Test {
   MatrixXf H = MatrixXf::Random(m, n);
   MatrixXf R = MatrixXf::Random(m, m);
   MatrixXf P = MatrixXf::Random(n, n);
+  std::string exception_err =
+    "The matrices used have the wrong dimensions, an invalid_argument excpetion is expected";
 
   void SetUp()
   {}
@@ -455,35 +457,47 @@ struct KalmanExceptions : public ::testing::Test {
  */
 TEST_F(KalmanExceptions, handlesDimensionalityIssues)
 {
-  EXPECT_THROW(kalman.setInitial(x0, P0), std::invalid_argument);
+  EXPECT_THROW(kalman.setInitial(x0, P0), std::invalid_argument)
+    <<exception_err;
   P0=  MatrixXf::Zero(k, m);
   VectorXf x0 = VectorXf::Zero(n);
-  EXPECT_THROW(kalman.setInitial(x0, P0), std::invalid_argument);
+  EXPECT_THROW(kalman.setInitial(x0, P0), std::invalid_argument)
+    <<exception_err;
   MatrixXf A = MatrixXf::Random(k, m);
-  EXPECT_THROW(kalman.updateA(A), std::invalid_argument);
-  EXPECT_THROW(kalman.setModels(A, Q, H, R), std::invalid_argument);
+  EXPECT_THROW(kalman.updateA(A), std::invalid_argument)
+    <<exception_err;
+  EXPECT_THROW(kalman.setModels(A, Q, H, R), std::invalid_argument)
+    <<exception_err;
   A = MatrixXf::Random(n, n);
   Q = MatrixXf::Random(k, m);
-  EXPECT_THROW(kalman.setModels(A, Q, H, R), std::invalid_argument);
+  EXPECT_THROW(kalman.setModels(A, Q, H, R), std::invalid_argument)
+    <<exception_err;
   Q = MatrixXf::Random(n, n);
   H = MatrixXf::Random(k, m);
-  EXPECT_THROW(kalman.setModels(A, Q, H, R), std::invalid_argument);
+  EXPECT_THROW(kalman.setModels(A, Q, H, R), std::invalid_argument)
+    <<exception_err;
   H = MatrixXf::Random(n, n);
   R =MatrixXf::Random(k, m);
-  EXPECT_THROW(kalman.setModels(A, Q, H, R), std::invalid_argument);
+  EXPECT_THROW(kalman.setModels(A, Q, H, R), std::invalid_argument)
+    <<exception_err;
   A = MatrixXf::Random(k, m);
-  EXPECT_THROW(kalman.setModels(A, B, Q, H, R), std::invalid_argument);
+  EXPECT_THROW(kalman.setModels(A, B, Q, H, R), std::invalid_argument)
+    <<exception_err;
   A = MatrixXf::Random(n, n);
   Q = MatrixXf::Random(k, m);
-  EXPECT_THROW(kalman.setModels(A, B, Q, H, R), std::invalid_argument);
+  EXPECT_THROW(kalman.setModels(A, B, Q, H, R), std::invalid_argument)
+    <<exception_err;
   Q = MatrixXf::Random(n, n);
   H = MatrixXf::Random(k, m);
-  EXPECT_THROW(kalman.setModels(A, B, Q, H, R), std::invalid_argument);
+  EXPECT_THROW(kalman.setModels(A, B, Q, H, R), std::invalid_argument)
+    <<exception_err;
   H = MatrixXf::Random(n, n);
   R =MatrixXf::Random(k, m);
   EXPECT_THROW(kalman.updateR(R), std::invalid_argument);
-  EXPECT_THROW(kalman.setModels(A, B, Q, H, R), std::invalid_argument);
+  EXPECT_THROW(kalman.setModels(A, B, Q, H, R), std::invalid_argument)
+    <<exception_err;
   R = MatrixXf::Random(m, m);
   B =MatrixXf::Random(k, m);
-  EXPECT_THROW(kalman.setModels(A, B, Q, H, R), std::invalid_argument);
+  EXPECT_THROW(kalman.setModels(A, B, Q, H, R), std::invalid_argument)
+    <<exception_err;
 }


### PR DESCRIPTION
## Description
Adding New Tests to KalmanMultivariate.cpp//hpp
## New Tests
1. Tests for Exceptions
As new Exceptions have been added to the KalmanMultivariate code they need testing. This Pull request provides tests for those exceptions
2. Tests for multiple filters
The current version of the tests of the Kalman filter includes tests on the first filter operation on different initial conditions. These new tests include also a test to check if the filter operation is stable by repeatedly making this operation in only one case to see the evolution of the initial state vector and covariance matrix and to check that they evolve correctly.
3. Tests for Identity
By analysing the mathematical operations of the filter a new test has been created which initializes all the matrices of the model in a way that the State vector(x) and the covariance matrix (P) remain always the same (randomly initialised) even when performing several filter() operations.