### PR TITLE
STM: Fixed bug in IdleTest

### DIFF
--- a/test/src/state_machine/state.test.cpp
+++ b/test/src/state_machine/state.test.cpp
@@ -401,7 +401,7 @@ TEST_F(IdleTest, handlesAllInitialised)
 
     bool calibrate_command = checkCalibrateCommand(log, telemetry_data);
 
-    if (!has_emergency && !calibrate_command) {
+    if (!has_emergency && calibrate_command) {
       bool all_initialised = checkModulesInitialised(log, embrakes_data, nav_data, batteries_data,
                                                      telemetry_data, sensors_data, motors_data);
       hyped::state_machine::State *new_state = state->checkTransition(log);


### PR DESCRIPTION
We would wrongfully discard cases where `calibrate_command` was set as opposed to those where that was not the case. This leads to the `IdleTest::handlesAllInitialised` failing randomly because a) it expects a transition where none can occur (due to not having received the calibrate command in the first place) and b) the number of tests is too small to "guarantee" that case occurring every time.