### PR TITLE
QA: Fix for Quaternion edge case

### DIFF
--- a/test/src/utils/quaternion.test.cpp
+++ b/test/src/utils/quaternion.test.cpp
@@ -124,7 +124,7 @@ struct QuaternionConstruction : public::testing::Test
     void SetUp()
     {
         std::srand(time(0));
-        kValue = rand()%1000;
+        kValue = rand() % 1000 + 1;
     }
 };
 
@@ -163,7 +163,7 @@ struct QuaternionFunctionality : public::testing::Test
     void SetUp()
     {
         std::srand(time(0));
-        kValue = rand()%1000;
+        kValue = rand() % 1000 + 1;
         quaternion_one = Quaternion<int>(rand()%1000, rand()%1000, rand()%1000, rand()%1000);
         quaternion_two = Quaternion<int>(rand()%1000, rand()%1000, rand()%1000, rand()%1000);
     }


### PR DESCRIPTION
## Description
Github actions test compilation threw an error with handleAutoMultiplication test in the Quaternion Test suite. This is a fix to ensure that kValue is not initialized to 0.

## Changes
- QuaternionFunctionality Structure (Changed kValue random to between 1 and 1000)
- QuaternionConstruction Structure (Changed kValue random to between 1 and 1000)

## Additional Info 
Passes tests on a local machine and passes commit checks. Needs to be tested on the Github actions to ensure it is functioning, as that was were the error arose.