### PR TITLE
qa-Codecov-Problem

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -22,6 +22,7 @@ jobs:
       run: make coverage
     - uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: ./test/coverage/covdata/hyped.covdata # optional
         name: Codecov-umbrella # optional
         fail_ci_if_error: true # optional (default = false)


### PR DESCRIPTION
## Description
Solves the problem that we were having with codecov. Now it should not fail randomly when updated.


## Changes
- Uploaded the token of codecov to Github Secrets and used it in the GitHub action, this should not be required as Hyped is public but the error message was asking for the token. Another possible issue is that we are using version 1 of Codecov, I will try to read more about that.
